### PR TITLE
Fixing custom manager behavior in admin factory

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -2,6 +2,8 @@
 
 namespace LAG\AdminBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -45,71 +47,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 // admins configuration
-                ->arrayNode('admins')
-                    ->prototype('array')
-                        ->children()
-                            ->scalarNode('entity')->end()
-                            ->scalarNode('form')->end()
-                            ->scalarNode('max_per_page')->end()
-                            ->scalarNode('controller')->defaultValue('LAGAdminBundle:Generic')->end()
-                            ->scalarNode('manager')->defaultValue('LAG\AdminBundle\Manager\GenericManager')->end()
-                            // actions configurations
-                            ->arrayNode('actions')
-                                ->useAttributeAsKey('name')
-                                ->prototype('array')
-                                    ->children()
-                                        ->scalarNode('title')->end()
-                                        ->arrayNode('permissions')
-                                            ->defaultValue(['ROLE_USER'])
-                                            ->prototype('scalar')->end()
-                                        ->end()
-                                        ->arrayNode('export')
-                                            ->prototype('scalar')->end()
-                                        ->end()
-                                        ->arrayNode('order')
-                                            ->prototype('array')
-                                                ->children()
-                                                    ->scalarNode('field')->end()
-                                                    ->scalarNode('order')->end()
-                                                ->end()
-                                            ->end()
-                                        ->end()
-                                        ->arrayNode('fields')
-                                            ->prototype('array')
-                                                ->children()
-                                                    ->scalarNode('type')->end()
-                                                    ->arrayNode('options')
-                                                        ->prototype('variable')->end()
-                                                    ->end()
-                                                ->end()
-                                            ->end()
-                                        ->end()
-                                        ->arrayNode('filters')
-                                            ->prototype('scalar')->end()
-                                        ->end()
-                                        ->arrayNode('batch')
-                                            ->prototype('variable')->end()
-                                        ->end()
-                                        ->arrayNode('actions')
-                                            ->prototype('array')
-                                                ->children()
-                                                    ->scalarNode('title')->end()
-                                                    ->scalarNode('route')->end()
-                                                    ->scalarNode('target')->end()
-                                                    ->scalarNode('icon')->end()
-                                                    ->arrayNode('parameters')
-                                                        ->prototype('array')
-                                                        ->end()
-                                                    ->end()
-                                                ->end()
-                                            ->end()
-                                        ->end()
-                                    ->end()
-                                ->end()
-                            ->end()
-                        ->end()
-                    ->end()
-                ->end()
+                ->append($this->getAdminsConfigurationNode())
                 // menus configurations
                 ->arrayNode('menus')
                     ->prototype('array')
@@ -142,5 +80,80 @@ class Configuration implements ConfigurationInterface
         ->end();
 
         return $treeBuilder;
+    }
+
+    /**
+     * @return ArrayNodeDefinition|NodeDefinition
+     */
+    public function getAdminsConfigurationNode()
+    {
+        $builder = new TreeBuilder();
+        $node = $builder->root('admins');
+
+        $node
+            ->prototype('array')
+                ->children()
+                    ->scalarNode('entity')->end()
+                    ->scalarNode('form')->end()
+                    ->scalarNode('max_per_page')->end()
+                    ->scalarNode('controller')->defaultValue('LAGAdminBundle:Generic')->end()
+                    ->scalarNode('manager')->defaultValue('LAG\AdminBundle\Manager\GenericManager')->end()
+                    // actions configurations
+                    ->arrayNode('actions')
+                        ->useAttributeAsKey('name')
+                        ->prototype('array')
+                            ->children()
+                                ->scalarNode('title')->end()
+                                ->arrayNode('permissions')
+                                    ->defaultValue(['ROLE_USER'])
+                                    ->prototype('scalar')->end()
+                                ->end()
+                                ->arrayNode('export')
+                                    ->prototype('scalar')->end()
+                                ->end()
+                                ->arrayNode('order')
+                                    ->prototype('array')
+                                        ->children()
+                                            ->scalarNode('field')->end()
+                                            ->scalarNode('order')->end()
+                                        ->end()
+                                    ->end()
+                                ->end()
+                                ->arrayNode('fields')
+                                    ->prototype('array')
+                                        ->children()
+                                            ->scalarNode('type')->end()
+                                            ->arrayNode('options')
+                                                ->prototype('variable')->end()
+                                            ->end()
+                                        ->end()
+                                    ->end()
+                                ->end()
+                                ->arrayNode('filters')
+                                    ->prototype('scalar')->end()
+                                ->end()
+                                ->arrayNode('batch')
+                                    ->prototype('variable')->end()
+                                ->end()
+                                ->arrayNode('actions')
+                                    ->prototype('array')
+                                        ->children()
+                                            ->scalarNode('title')->end()
+                                            ->scalarNode('route')->end()
+                                            ->scalarNode('target')->end()
+                                            ->scalarNode('icon')->end()
+                                            ->arrayNode('parameters')
+                                                ->prototype('array')
+                                                ->end()
+                                            ->end()
+                                        ->end()
+                                    ->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+        return $node;
     }
 }

--- a/DependencyInjection/ManagerCompilerPass.php
+++ b/DependencyInjection/ManagerCompilerPass.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace LAG\AdminBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class ManagerCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has('lag.admin.factory')) {
+            return;
+        }
+
+        $definition = $container->findDefinition('lag.admin.factory');
+        $taggedServices = $container->findTaggedServiceIds('lag.manager');
+
+        foreach ($taggedServices as $id => $tags) {
+            $definition->addMethodCall(
+                'addCustomManager',
+                [$id, new Reference($id)]
+            );
+        }
+    }
+}

--- a/Event/AdminFactoryEvent.php
+++ b/Event/AdminFactoryEvent.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace LAG\AdminBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class AdminFactoryEvent extends Event
+{
+    const ADMIN_CREATION = 'lag.admin.adminCreation';
+
+    protected $adminsConfiguration = [];
+
+    /**
+     * @return array
+     */
+    public function getAdminsConfiguration()
+    {
+        return $this->adminsConfiguration;
+    }
+
+    /**
+     * @param array $adminsConfiguration
+     */
+    public function setAdminsConfiguration($adminsConfiguration)
+    {
+        $this->adminsConfiguration = $adminsConfiguration;
+    }
+}

--- a/LAGAdminBundle.php
+++ b/LAGAdminBundle.php
@@ -3,6 +3,7 @@
 namespace LAG\AdminBundle;
 
 use LAG\AdminBundle\DependencyInjection\FieldCompilerPass;
+use LAG\AdminBundle\DependencyInjection\ManagerCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -15,6 +16,7 @@ class LAGAdminBundle extends Bundle
 
         // register field compiler pass
         $container->addCompilerPass(new FieldCompilerPass());
+        $container->addCompilerPass(new ManagerCompilerPass());
     }
 
     public function getContainerExtension()
@@ -36,7 +38,5 @@ class LAGAdminBundle extends Bundle
         if ($this->extension) {
             return $this->extension;
         }
-
-        return;
     }
 }


### PR DESCRIPTION
Fixing custom manager behavior in admin factory, now custom managers needs to be tagged with "lag_admin.manager" and can be called using their service's id in admin configuration

Refactoring configuration to authorize usage of admin validation for custom admins
Re-implementing global admin creation event to allow custom admin to be created