### PR TITLE
feature: add a resource event dispatcher to ease multiple specific and generic events dispatching

### DIFF
--- a/src/Event/OperationEvents.php
+++ b/src/Event/OperationEvents.php
@@ -6,12 +6,6 @@ namespace LAG\AdminBundle\Event;
 
 enum OperationEvents: string
 {
-    public const OPERATION_CREATE = 'lag_admin.operation.create';
-    public const OPERATION_CREATED = 'lag_admin.operation.created';
-
-    public const RESOURCE_OPERATION_CREATE_PATTERN = 'lag_admin.%s.operation.%s.create';
-    public const RESOURCE_OPERATION_CREATED_PATTERN = 'lag_admin.%s.operation.%s.created';
-
-    public const OPERATION_CREATE_PATTERN = 'lag_admin.%s.operation.create';
-    public const OPERATION_CREATED_PATTERN = 'lag_admin.%s.operation.created';
+    public const OPERATION_CREATE = 'operation.create';
+    public const OPERATION_CREATED = 'operation.created';
 }

--- a/src/Event/ResourceEvents.php
+++ b/src/Event/ResourceEvents.php
@@ -6,9 +6,6 @@ namespace LAG\AdminBundle\Event;
 
 class ResourceEvents
 {
-    public const RESOURCE_CREATE = 'lag_admin.resource.create';
-    public const RESOURCE_CREATED = 'lag_admin.resource.created';
-    public const RESOURCE_CREATE_PATTERN = 'lag_admin.resource.%s.create';
-    public const RESOURCE_CREATED_PATTERN = 'lag_admin.resource.%s.created';
-    public const RESOURCE_COLLECTION_LOADED = 'lag_admin.resources.loaded';
+    public const string RESOURCE_CREATE = 'resource.create';
+    public const string RESOURCE_CREATED = 'resource.created';
 }

--- a/src/EventDispatcher/ResourceEventDispatcher.php
+++ b/src/EventDispatcher/ResourceEventDispatcher.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\EventDispatcher;
+
+use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use function Symfony\Component\String\u;
+
+final readonly class ResourceEventDispatcher implements ResourceEventDispatcherInterface
+{
+    public function __construct(
+        private EventDispatcherInterface $eventDispatcher,
+    ) {
+    }
+
+    public function dispatchResourceEvents(
+        Event $event,
+        string $eventName,
+        string $applicationName,
+        string $resourceName,
+        ?string $operationName = null,
+    ): void {
+        $eventName = u($eventName);
+        $eventNames = [
+            $eventName->prepend('lag_admin.'),
+            $eventName->replace('resource', '{application}.{resource}'),
+        ];
+
+        // As the application and resource names are mandatory, the operation can be optional for build resource events
+        // for instance
+        if ($operationName) {
+            $eventNames = [
+                $eventName->prepend('lag_admin.'),
+                $eventName->replace('operation', '{application}.{resource}.{operation}')
+            ];
+        }
+
+        foreach ($eventNames as $eventNameString) {
+            $eventName = $eventNameString
+                ->replace('{application}', $applicationName)
+                ->replace('{resource}', $resourceName)
+                ->replace('{operation}', $operationName ?? '')
+                ->toString()
+            ;
+            $this->eventDispatcher->dispatch($event, $eventName);
+        }
+    }
+}

--- a/src/EventDispatcher/ResourceEventDispatcherInterface.php
+++ b/src/EventDispatcher/ResourceEventDispatcherInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\EventDispatcher;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Add a single entrypoint to dispatch resources and operations generics and specifics events.
+ *
+ * For instance, if the "my_resource" resource of "my_application" application is created, the following events should
+ * be dispatched:
+ * - lag_admin.resource.created (generic)
+ * - my_application.my_resource.created (specific)
+ * - lag_admin.my_resource.created (specific)
+ */
+interface ResourceEventDispatcherInterface
+{
+    public function dispatchResourceEvents(
+        Event $event,
+        string $eventName,
+        string $applicationName,
+        string $resourceName,
+        ?string $operationName = null,
+    ): void;
+}

--- a/tests/phpunit/EventDispatcher/ResourceEventDispatcherTest.php
+++ b/tests/phpunit/EventDispatcher/ResourceEventDispatcherTest.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\EventDispatcher;
+
+use LAG\AdminBundle\Event\ResourceEvent;
+use LAG\AdminBundle\Event\ResourceEvents;
+use LAG\AdminBundle\EventDispatcher\ResourceEventDispatcher;
+use LAG\AdminBundle\Resource\Metadata\Resource;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+final class ResourceEventDispatcherTest extends TestCase
+{
+    private ResourceEventDispatcher $resourceEventDispatcher;
+    private MockObject $eventDispatcher;
+
+    #[Test]
+    public function itDispatchEvents(): void
+    {
+        $resource = new Resource(name: 'my_resource', application: 'my_application');
+        $event = new ResourceEvent($resource);
+
+        $this->eventDispatcher
+            ->expects(self::exactly(2))
+            ->method('dispatch')
+            ->willReturnCallback(function (ResourceEvent $expectedEvent, string $eventName) use ($event): ResourceEvent {
+                self::assertEquals($expectedEvent, $event);
+                self::assertContains($eventName, [
+                    'lag_admin.resource.create',
+                    'my_application.my_resource.create',
+                ]);
+
+                return $expectedEvent;
+            })
+        ;
+
+        $this->resourceEventDispatcher->dispatchResourceEvents(
+            $event,
+            ResourceEvents::RESOURCE_CREATE,
+            'my_application',
+            'my_resource',
+        );
+
+    }
+
+    protected function setUp(): void
+    {
+        $this->eventDispatcher = self::createMock(EventDispatcherInterface::class);
+        $this->resourceEventDispatcher = new ResourceEventDispatcher($this->eventDispatcher);
+    }
+}


### PR DESCRIPTION
Add an specific event dispatcher to ease multiple resource events dispatching in the application. It allows to dispatch generic events for each resource (used by the core system) and specific events for each resources (used by the developer)