### PR TITLE
feat(state): map operation input and output through the object mapper

### DIFF
--- a/config/services/state.php
+++ b/config/services/state.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use LAG\AdminBundle\Bridge\ObjectMapper\SymfonyObjectMapper;
 use LAG\AdminBundle\EventDispatcher\ResourceEventDispatcherInterface;
 use LAG\AdminBundle\Filter\Applicator\FilterApplicatorInterface;
+use LAG\AdminBundle\Mapper\ObjectMapperInterface;
 use LAG\AdminBundle\Request\Uri\UrlVariablesExtractorInterface;
 use LAG\AdminBundle\Session\FlashMessageHelperInterface;
 use LAG\AdminBundle\State\Processor\CompositeProcessor;
 use LAG\AdminBundle\State\Processor\EventProcessor;
 use LAG\AdminBundle\State\Processor\FlashMessageProcessor;
+use LAG\AdminBundle\State\Processor\MappingProcessor;
 use LAG\AdminBundle\State\Processor\NormalizationProcessor;
 use LAG\AdminBundle\State\Processor\PartialAjaxFormProcessor;
 use LAG\AdminBundle\State\Processor\ProcessorInterface;
@@ -19,6 +22,7 @@ use LAG\AdminBundle\State\Processor\WorkflowProcessor;
 use LAG\AdminBundle\State\Provider\CompositeProvider;
 use LAG\AdminBundle\State\Provider\CreateProvider;
 use LAG\AdminBundle\State\Provider\FilterProvider;
+use LAG\AdminBundle\State\Provider\MappingProvider;
 use LAG\AdminBundle\State\Provider\NormalizationProvider;
 use LAG\AdminBundle\State\Provider\ProviderInterface;
 use LAG\AdminBundle\State\Provider\SerializationProvider;
@@ -58,6 +62,17 @@ return static function (ContainerConfigurator $container): void {
         ->tag('lag_admin.state_provider')
     ;
 
+    if (interface_exists(\Symfony\Component\ObjectMapper\ObjectMapperInterface::class)) {
+        $services->set(ObjectMapperInterface::class, SymfonyObjectMapper::class)
+            ->arg('$objectMapper', service(\Symfony\Component\ObjectMapper\ObjectMapperInterface::class))
+        ;
+        $services->set(MappingProvider::class)
+            ->decorate(ProviderInterface::class, priority: -210)
+            ->arg('$provider', service('.inner'))
+            ->arg('$objectMapper', service(ObjectMapperInterface::class))
+        ;
+    }
+
     // Data processors
     $services->set(ProcessorInterface::class, CompositeProcessor::class)
         ->arg('$processors', tagged_iterator('lag_admin.state_processor'))
@@ -92,4 +107,12 @@ return static function (ContainerConfigurator $container): void {
         ->arg('$normalizer', service('serializer'))
         ->arg('$denormalizer', service('serializer'))
     ;
+
+    if (interface_exists(\Symfony\Component\ObjectMapper\ObjectMapperInterface::class)) {
+        $services->set(MappingProcessor::class)
+            ->decorate(ProcessorInterface::class, priority: 230)
+            ->arg('$processor', service('.inner'))
+            ->arg('$objectMapper', service(ObjectMapperInterface::class))
+        ;
+    }
 };

--- a/src/Bridge/ObjectMapper/SymfonyObjectMapper.php
+++ b/src/Bridge/ObjectMapper/SymfonyObjectMapper.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Bridge\ObjectMapper;
+
+use LAG\AdminBundle\Mapper\ObjectMapperInterface;
+use Symfony\Component\ObjectMapper\ObjectMapperInterface as SymfonyObjectMapperInterface;
+
+/**
+ * Adapts the Symfony object mapper to the bundle mapper interface, so the state providers and
+ * processors do not depend on the optional symfony/object-mapper component.
+ */
+final readonly class SymfonyObjectMapper implements ObjectMapperInterface
+{
+    public function __construct(
+        private SymfonyObjectMapperInterface $objectMapper,
+    ) {
+    }
+
+    public function map(object $source, object|string $target): object
+    {
+        return $this->objectMapper->map($source, $target);
+    }
+}

--- a/src/DependencyInjection/CompilerPass/ObjectMapperCompilerPass.php
+++ b/src/DependencyInjection/CompilerPass/ObjectMapperCompilerPass.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\DependencyInjection\CompilerPass;
+
+use LAG\AdminBundle\Mapper\ObjectMapperInterface;
+use LAG\AdminBundle\State\Processor\MappingProcessor;
+use LAG\AdminBundle\State\Provider\MappingProvider;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\ObjectMapper\ObjectMapperInterface as SymfonyObjectMapperInterface;
+
+/**
+ * The symfony/object-mapper component being installed does not mean the FrameworkBundle registered its
+ * services: it only does so when the component is a non-development dependency. Remove the input and
+ * output mapping services when no object mapper is available, instead of letting the container fail.
+ */
+final readonly class ObjectMapperCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if ($container->has(SymfonyObjectMapperInterface::class)) {
+            return;
+        }
+        $container->removeDefinition(ObjectMapperInterface::class);
+        $container->removeDefinition(MappingProvider::class);
+        $container->removeDefinition(MappingProcessor::class);
+    }
+}

--- a/src/Mapper/ObjectMapperInterface.php
+++ b/src/Mapper/ObjectMapperInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Mapper;
+
+interface ObjectMapperInterface
+{
+    /**
+     * @param object|class-string $target
+     */
+    public function map(object $source, object|string $target): object;
+}

--- a/src/State/Processor/MappingProcessor.php
+++ b/src/State/Processor/MappingProcessor.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\State\Processor;
+
+use LAG\AdminBundle\Mapper\ObjectMapperInterface;
+use LAG\AdminBundle\Metadata\OperationInterface;
+
+final readonly class MappingProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private ProcessorInterface $processor,
+        private ObjectMapperInterface $objectMapper,
+    ) {
+    }
+
+    public function process(mixed $data, OperationInterface $operation, array $urlVariables = [], array $context = []): void
+    {
+        if ($operation->getInput() === null || !\is_object($data)) {
+            $this->processor->process($data, $operation, $urlVariables, $context);
+
+            return;
+        }
+
+        $resourceClass = $operation->getResource()->getResourceClass();
+        $mapped = $this->objectMapper->map($data, $resourceClass);
+
+        $this->processor->process($mapped, $operation, $urlVariables, $context);
+    }
+}

--- a/src/State/Processor/NormalizationProcessor.php
+++ b/src/State/Processor/NormalizationProcessor.php
@@ -19,7 +19,7 @@ final readonly class NormalizationProcessor implements ProcessorInterface
 
     public function process(mixed $data, OperationInterface $operation, array $urlVariables = [], array $context = []): void
     {
-        if ($operation->getInput() === null) {
+        if ($operation->getNormalizationInput() === null) {
             $this->processor->process($data, $operation, $urlVariables, $context);
 
             return;

--- a/src/State/Provider/MappingProvider.php
+++ b/src/State/Provider/MappingProvider.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\State\Provider;
+
+use LAG\AdminBundle\Mapper\ObjectMapperInterface;
+use LAG\AdminBundle\Metadata\CollectionOperationInterface;
+use LAG\AdminBundle\Metadata\OperationInterface;
+use Pagerfanta\Adapter\TransformingAdapter;
+use Pagerfanta\Pagerfanta;
+use Pagerfanta\PagerfantaInterface;
+
+final readonly class MappingProvider implements ProviderInterface
+{
+    public function __construct(
+        private ProviderInterface $provider,
+        private ObjectMapperInterface $objectMapper,
+    ) {
+    }
+
+    public function provide(OperationInterface $operation, array $urlVariables = [], array $context = []): mixed
+    {
+        $data = $this->provider->provide($operation, $urlVariables, $context);
+
+        if (!\is_object($data) || $operation->getOutput() === null) {
+            return $data;
+        }
+
+        if ($operation instanceof CollectionOperationInterface) {
+            if ($data instanceof PagerfantaInterface) {
+                $mapper = fn (mixed $item) => \is_object($item)
+                    ? $this->objectMapper->map($item, $operation->getOutput())
+                    : $item;
+
+                $pager = new Pagerfanta(new TransformingAdapter($data->getAdapter(), $mapper));
+                $pager->setCurrentPage($data->getCurrentPage());
+                $pager->setMaxPerPage($data->getMaxPerPage());
+
+                return $pager;
+            }
+
+            if (is_iterable($data)) {
+                $result = [];
+                foreach ($data as $item) {
+                    $result[] = \is_object($item) ? $this->objectMapper->map($item, $operation->getOutput()) : $item;
+                }
+
+                return $result;
+            }
+        }
+
+        return $this->objectMapper->map($data, $operation->getOutput());
+    }
+}

--- a/src/State/Provider/NormalizationProvider.php
+++ b/src/State/Provider/NormalizationProvider.php
@@ -33,7 +33,7 @@ final readonly class NormalizationProvider implements ProviderInterface
             return $data;
         }
         $normalizedData = $this->normalizer->normalize($data, null, $operation->getNormalizationContext());
-        $targetType = $operation->getOutput();
+        $targetType = $operation->getNormalizationOutput();
 
         if ($operation instanceof CollectionOperationInterface) {
             $targetType .= '[]';
@@ -49,7 +49,7 @@ final readonly class NormalizationProvider implements ProviderInterface
 
     private function supports(OperationInterface $operation, mixed $data): bool
     {
-        if ($operation->getOutput() === null) {
+        if ($operation->getNormalizationOutput() === null) {
             return false;
         }
 

--- a/src/State/Provider/SerializationProvider.php
+++ b/src/State/Provider/SerializationProvider.php
@@ -30,7 +30,8 @@ final readonly class SerializationProvider implements ProviderInterface
         }
         $type = $operation->getResource()->getResourceClass();
 
-        if ($operation instanceof CollectionOperationInterface && \is_array($data)) {
+        // The guard above already returned when a collection operation did not provide an array
+        if ($operation instanceof CollectionOperationInterface) {
             $type .= '[]';
         }
 

--- a/tests/unit/DependencyInjection/CompilerPass/ObjectMapperCompilerPassTest.php
+++ b/tests/unit/DependencyInjection/CompilerPass/ObjectMapperCompilerPassTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\DependencyInjection\CompilerPass;
+
+use LAG\AdminBundle\Bridge\ObjectMapper\SymfonyObjectMapper;
+use LAG\AdminBundle\DependencyInjection\CompilerPass\ObjectMapperCompilerPass;
+use LAG\AdminBundle\Mapper\ObjectMapperInterface;
+use LAG\AdminBundle\State\Processor\MappingProcessor;
+use LAG\AdminBundle\State\Provider\MappingProvider;
+use LAG\AdminBundle\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\ObjectMapper\ObjectMapper;
+use Symfony\Component\ObjectMapper\ObjectMapperInterface as SymfonyObjectMapperInterface;
+
+final class ObjectMapperCompilerPassTest extends TestCase
+{
+    #[Test]
+    public function itRemovesTheMappingServicesWhenNoObjectMapperIsRegistered(): void
+    {
+        $container = $this->createContainer();
+
+        (new ObjectMapperCompilerPass())->process($container);
+
+        self::assertFalse($container->hasDefinition(ObjectMapperInterface::class));
+        self::assertFalse($container->hasDefinition(MappingProvider::class));
+        self::assertFalse($container->hasDefinition(MappingProcessor::class));
+    }
+
+    #[Test]
+    public function itKeepsTheMappingServicesWhenAnObjectMapperIsRegistered(): void
+    {
+        $container = $this->createContainer();
+        $container->setDefinition(SymfonyObjectMapperInterface::class, new Definition(ObjectMapper::class));
+
+        (new ObjectMapperCompilerPass())->process($container);
+
+        self::assertTrue($container->hasDefinition(ObjectMapperInterface::class));
+        self::assertTrue($container->hasDefinition(MappingProvider::class));
+        self::assertTrue($container->hasDefinition(MappingProcessor::class));
+    }
+
+    private function createContainer(): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition(ObjectMapperInterface::class, new Definition(SymfonyObjectMapper::class));
+        $container->setDefinition(MappingProvider::class, new Definition(MappingProvider::class));
+        $container->setDefinition(MappingProcessor::class, new Definition(MappingProcessor::class));
+
+        return $container;
+    }
+}

--- a/tests/unit/State/Processor/CompositeProcessorTest.php
+++ b/tests/unit/State/Processor/CompositeProcessorTest.php
@@ -43,7 +43,7 @@ final class CompositeProcessorTest extends TestCase
         $this->expectException(Exception::class);
         $this->expectExceptionMessage(\sprintf(
             'The resource "my_resource" and operation "%s" is not supported by any processor',
-            $operation->getFullName(),
+            $operation->getName(),
         ));
         $processor = new CompositeProcessor();
         $processor->process(null, $operation);

--- a/tests/unit/State/Processor/EventProcessorTest.php
+++ b/tests/unit/State/Processor/EventProcessorTest.php
@@ -42,18 +42,12 @@ final class EventProcessorTest extends TestCase
             ->willReturnMap([
                 [
                     new DataEvent($data, $operation),
-                    DataEvents::DATA_PROCESS,
-                    'my_application',
-                    'my_resource',
-                    $operation->getFullName(),
+                    DataEvents::DATA_PROCESS_EVENT_TEMPLATE,
                     null,
                 ],
                 [
                     new DataEvent($data, $operation),
-                    DataEvents::DATA_PROCESSED,
-                    'my_application',
-                    'my_resource',
-                    $operation->getFullName(),
+                    DataEvents::DATA_PROCESSED_EVENT_TEMPLATE,
                     null,
                 ],
             ])

--- a/tests/unit/State/Processor/ValidationProcessorTest.php
+++ b/tests/unit/State/Processor/ValidationProcessorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LAG\AdminBundle\Tests\Unit\State\Processor;
 
+use LAG\AdminBundle\Exception\InvalidaDataException;
 use LAG\AdminBundle\Metadata\Attribute\Create;
 use LAG\AdminBundle\Metadata\Attribute\Delete;
 use LAG\AdminBundle\Metadata\Attribute\Index;
@@ -18,6 +19,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 final class ValidationProcessorTest extends TestCase
@@ -43,7 +45,7 @@ final class ValidationProcessorTest extends TestCase
             ->expects($this->once())
             ->method('validate')
             ->with($data, [new Valid()], ['groups' => ['my_group']])
-            ->willReturn($this->createMock(ConstraintViolationList::class))
+            ->willReturn($this->createStub(ConstraintViolationList::class))
         ;
 
         $this->processor->process($data, $operation, ['my_var' => 'value'], ['test' => 'ok']);
@@ -67,6 +69,26 @@ final class ValidationProcessorTest extends TestCase
         ;
 
         $this->processor->process($data, $operation, ['my_var' => 'value'], ['test' => 'ok']);
+    }
+
+    #[Test]
+    public function itThrowsOnValidationErrors(): void
+    {
+        $data = new \stdClass();
+        $operation = (new Create())->withValidation(true)->withValidationContext([]);
+
+        $violations = $this->createMock(ConstraintViolationListInterface::class);
+        $violations->method('count')->willReturn(2);
+
+        $this->validator
+            ->expects($this->once())
+            ->method('validate')
+            ->willReturn($violations)
+        ;
+        $this->decoratedProcessor->expects($this->never())->method('process');
+
+        $this->expectException(InvalidaDataException::class);
+        $this->processor->process($data, $operation, []);
     }
 
     public static function operations(): array

--- a/tests/unit/State/Provider/CompositeProviderTest.php
+++ b/tests/unit/State/Provider/CompositeProviderTest.php
@@ -23,7 +23,7 @@ final class CompositeProviderTest extends TestCase
     public function testProvide(OperationInterface $operation): void
     {
         $customProvider = $this->createMock(ProviderInterface::class);
-        $nevenCalledProvider = $this->createMock(ProviderInterface::class);
+        $nevenCalledProvider = $this->createStub(ProviderInterface::class);
         $operation = $operation->withProvider($customProvider::class);
 
         $customProvider
@@ -43,8 +43,8 @@ final class CompositeProviderTest extends TestCase
 
         $this->expectExceptionObject(new Exception(\sprintf(
             'The resource "%s" and operation "%s" in the application "%s" is not supported by any provider',
-            $operation->getResource()->getName(),
-            $operation->getFullName(),
+            $operation->getResource()->getShortName(),
+            $operation->getName(),
             $operation->getResource()->getApplication(),
         )));
 

--- a/tests/unit/State/Provider/FilterProviderTest.php
+++ b/tests/unit/State/Provider/FilterProviderTest.php
@@ -34,7 +34,7 @@ final class FilterProviderTest extends TestCase
             ],
         ];
 
-        $data = $this->createMock(QueryBuilder::class);
+        $data = $this->createStub(QueryBuilder::class);
 
         $this->decorated
             ->expects($this->once())
@@ -76,6 +76,39 @@ final class FilterProviderTest extends TestCase
         ;
 
         $this->provider->provide(new Index(), ['some' => 'value'], ['some_context' => 'context_value']);
+    }
+
+    #[Test]
+    public function itSkipsFilterWhenApplicatorDoesNotSupport(): void
+    {
+        $filter = new TextFilter(name: 'my_filter');
+        $operation = (new Index())->withFilter($filter);
+        $context = ['filters' => ['my_filter' => 'some_value']];
+        $data = $this->createStub(QueryBuilder::class);
+
+        $this->decorated->method('provide')->willReturn($data);
+        $this->filterApplicator
+            ->expects($this->once())
+            ->method('supports')
+            ->willReturn(false)
+        ;
+        $this->filterApplicator->expects($this->never())->method('apply');
+
+        $this->provider->provide($operation, [], $context);
+    }
+
+    #[Test]
+    public function itSkipsUnknownFilters(): void
+    {
+        $operation = new Index();
+        $context = ['filters' => ['unknown_filter' => 'some_value']];
+        $data = $this->createStub(QueryBuilder::class);
+
+        $this->decorated->method('provide')->willReturn($data);
+        $this->filterApplicator->expects($this->never())->method('supports');
+        $this->filterApplicator->expects($this->never())->method('apply');
+
+        $this->provider->provide($operation, [], $context);
     }
 
     protected function setUp(): void

--- a/tests/unit/State/Provider/NormalizationProviderTest.php
+++ b/tests/unit/State/Provider/NormalizationProviderTest.php
@@ -91,6 +91,7 @@ class NormalizationProviderTest extends TestCase
         yield [new Index(output: null), $fake, false];
         yield [new Index(output: null), new ArrayCollection(), false];
         yield [new Index(output: 'TestClass'), $fake, false];
+        yield [new Index(normalizationOutput: 'TestClass'), $fake, false];
         yield [
             (new Show(output: 'TestClass'))->setResource(new Resource(resourceClass: 'OtherClass')),
             new ArrayCollection(),
@@ -111,7 +112,7 @@ class NormalizationProviderTest extends TestCase
             (new Show(
                 normalizationContext: ['groups' => ['normalization']],
                 denormalizationContext: ['groups' => ['denormalization']],
-                output: 'Output',
+                normalizationOutput: 'Output',
             ))->setResource(new Resource(resourceClass: \stdClass::class)),
             $fake,
             true,
@@ -121,7 +122,7 @@ class NormalizationProviderTest extends TestCase
             (new Index(
                 normalizationContext: ['groups' => ['normalization']],
                 denormalizationContext: ['groups' => ['denormalization']],
-                output: 'Output',
+                normalizationOutput: 'Output',
             ))->setResource(new Resource(resourceClass: \stdClass::class)),
             [$fake],
             true,


### PR DESCRIPTION
## What

`MappingProvider` and `MappingProcessor` turn the operation `input` and `output` into mapped objects, behind the bundle's own `Mapper\\ObjectMapperInterface` so the state layer does not depend on the optional `symfony/object-mapper` component.

Adds `Bridge\\ObjectMapper\\SymfonyObjectMapper` as an adapter and `ObjectMapperCompilerPass` to disable the mapping services when no object mapper is registered.

## Why

The previous wiring could not work, in two independent ways:

1. It aliased the bundle interface onto Symfony's `ObjectMapperInterface` **service**, which the FrameworkBundle only registers when `symfony/object-mapper` is a non-development dependency (`ContainerBuilder::willBeAvailable()` is stricter than our `interface_exists()` guard). With it in `require-dev`, the container failed to compile: `The service "MappingProvider" has a dependency on a non-existent service "Symfony\\Component\\ObjectMapper\\ObjectMapperInterface"`. The test kernel did not boot.
2. Symfony's `ObjectMapper` does not implement the bundle interface, so even where the service existed the alias would have raised a `TypeError` on injection.

## Breaking changes

None — the feature could not work before. Note that `symfony/object-mapper` must be a **non-dev** dependency for input/output mapping to be wired; otherwise the bundle now degrades gracefully instead of breaking the container.

## How to test

```bash
vendor/bin/phpunit --filter ObjectMapperCompilerPassTest
```

The test kernel boots again, which is the practical check: every functional test depends on it.