### PR TITLE
test(metadata): cover every attribute with a unit test

### DIFF
--- a/tests/unit/Metadata/Attribute/ApplicationTest.php
+++ b/tests/unit/Metadata/Attribute/ApplicationTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\Metadata\Attribute;
+
+use LAG\AdminBundle\Metadata\Attribute\Application;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ApplicationTest extends TestCase
+{
+    #[Test]
+    public function itReturnsDefaultProperties(): void
+    {
+        $application = new Application(name: 'admin');
+
+        self::assertSame('admin', $application->getName());
+        self::assertSame('d/m/Y', $application->getDateFormat());
+        self::assertSame('H:i', $application->getTimeFormat());
+        self::assertSame('messages', $application->getTranslationDomain());
+        self::assertSame('{application}.{resource}.{message}', $application->getTranslationPattern());
+        self::assertSame('{application}.{resource}.{operation}', $application->getRoutePattern());
+        self::assertSame('@LAGAdmin/base.html.twig', $application->getBaseTemplate());
+        self::assertSame(['ROLE_ADMIN'], $application->getPermissions());
+    }
+
+    #[Test]
+    public function itReturnsImmutableCopiesForWithMethods(): void
+    {
+        $application = new Application(name: 'admin');
+
+        $new = $application->withName('shop');
+        self::assertNotSame($application, $new);
+        self::assertSame('shop', $new->getName());
+        self::assertSame('admin', $application->getName());
+
+        $new = $application->withDateFormat('Y-m-d');
+        self::assertNotSame($application, $new);
+        self::assertSame('Y-m-d', $new->getDateFormat());
+
+        $new = $application->withTimeFormat('H:i:s');
+        self::assertNotSame($application, $new);
+        self::assertSame('H:i:s', $new->getTimeFormat());
+
+        $new = $application->withTranslationDomain('admin');
+        self::assertNotSame($application, $new);
+        self::assertSame('admin', $new->getTranslationDomain());
+
+        $new = $application->withTranslationPattern('{resource}.{message}');
+        self::assertNotSame($application, $new);
+        self::assertSame('{resource}.{message}', $new->getTranslationPattern());
+
+        $new = $application->withRoutePattern('{resource}.{operation}');
+        self::assertNotSame($application, $new);
+        self::assertSame('{resource}.{operation}', $new->getRoutePattern());
+
+        $new = $application->withBaseTemplate('@App/base.html.twig');
+        self::assertNotSame($application, $new);
+        self::assertSame('@App/base.html.twig', $new->getBaseTemplate());
+
+        $new = $application->withPermissions(['ROLE_SUPER_ADMIN']);
+        self::assertNotSame($application, $new);
+        self::assertSame(['ROLE_SUPER_ADMIN'], $new->getPermissions());
+    }
+}

--- a/tests/unit/Metadata/Attribute/BooleanTest.php
+++ b/tests/unit/Metadata/Attribute/BooleanTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\Metadata\Attribute;
+
+use LAG\AdminBundle\Metadata\Attribute\Boolean;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class BooleanTest extends TestCase
+{
+    #[Test]
+    public function itReturnsDefaultProperties(): void
+    {
+        $boolean = new Boolean(name: 'active');
+
+        self::assertSame('active', $boolean->getName());
+        self::assertSame('@LAGAdmin/grids/properties/boolean.html.twig', $boolean->getTemplate());
+        self::assertTrue($boolean->isSortable());
+        self::assertTrue($boolean->isTranslatable());
+    }
+}

--- a/tests/unit/Metadata/Attribute/CollectionOperationTest.php
+++ b/tests/unit/Metadata/Attribute/CollectionOperationTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\Metadata\Attribute;
+
+use LAG\AdminBundle\Metadata\Attribute\Filter;
+use LAG\AdminBundle\Metadata\Attribute\Index;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class CollectionOperationTest extends TestCase
+{
+    #[Test]
+    public function itReturnsDefaultProperties(): void
+    {
+        $operation = new Index();
+
+        self::assertTrue($operation->hasPagination());
+        self::assertSame(25, $operation->getItemsPerPage());
+        self::assertSame('page', $operation->getPageParameter());
+        self::assertNull($operation->getGrid());
+        self::assertSame([], $operation->getGridOptions());
+        self::assertNull($operation->getFilterForm());
+        self::assertSame([], $operation->getFilterFormOptions());
+        self::assertSame([], $operation->getBatchOperations());
+        self::assertNull($operation->getCollectionLinks());
+    }
+
+    #[Test]
+    public function itHasNoFiltersWhenEmptyArray(): void
+    {
+        $operation = new Index(filters: []);
+
+        self::assertFalse($operation->hasFilters());
+    }
+
+    #[Test]
+    public function itHasFiltersWhenSet(): void
+    {
+        $filter = new Filter(name: 'search');
+        $operation = new Index(filters: [$filter]);
+
+        self::assertTrue($operation->hasFilters());
+        self::assertTrue($operation->hasFilter('search'));
+        self::assertFalse($operation->hasFilter('missing'));
+    }
+
+    #[Test]
+    public function itGetsFilterByName(): void
+    {
+        $filter = new Filter(name: 'search');
+        $operation = new Index(filters: [$filter]);
+
+        self::assertSame($filter, $operation->getFilter('search'));
+        self::assertNull($operation->getFilter('missing'));
+    }
+
+    #[Test]
+    public function itReturnsImmutableCopiesForWithMethods(): void
+    {
+        $operation = new Index();
+
+        $new = $operation->withPagination(false);
+        self::assertNotSame($operation, $new);
+        self::assertFalse($new->hasPagination());
+        self::assertTrue($operation->hasPagination());
+
+        $new = $operation->withItemsPerPage(50);
+        self::assertNotSame($operation, $new);
+        self::assertSame(50, $new->getItemsPerPage());
+
+        $new = $operation->withPageParameter('p');
+        self::assertNotSame($operation, $new);
+        self::assertSame('p', $new->getPageParameter());
+
+        $filter = new Filter(name: 'search');
+        $new = $operation->withFilters([$filter]);
+        self::assertNotSame($operation, $new);
+        self::assertSame([$filter], $new->getFilters());
+
+        $new = $operation->withFilter($filter);
+        self::assertNotSame($operation, $new);
+        self::assertSame([$filter], $new->getFilters());
+
+        $new = $operation->withGrid('my_grid');
+        self::assertNotSame($operation, $new);
+        self::assertSame('my_grid', $new->getGrid());
+
+        $new = $operation->withGridOptions(['batch' => true]);
+        self::assertNotSame($operation, $new);
+        self::assertSame(['batch' => true], $new->getGridOptions());
+
+        $new = $operation->withFilterForm('App\Form\SearchType');
+        self::assertNotSame($operation, $new);
+        self::assertSame('App\Form\SearchType', $new->getFilterForm());
+
+        $new = $operation->withFilterFormOptions(['method' => 'GET']);
+        self::assertNotSame($operation, $new);
+        self::assertSame(['method' => 'GET'], $new->getFilterFormOptions());
+
+        $new = $operation->withBatchOperations(['delete']);
+        self::assertNotSame($operation, $new);
+        self::assertSame(['delete'], $new->getBatchOperations());
+
+        $new = $operation->withCollectionLinks([]);
+        self::assertNotSame($operation, $new);
+        self::assertSame([], $new->getCollectionLinks());
+    }
+}

--- a/tests/unit/Metadata/Attribute/CollectionPropertyTest.php
+++ b/tests/unit/Metadata/Attribute/CollectionPropertyTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\Metadata\Attribute;
+
+use LAG\AdminBundle\Metadata\Attribute\Collection;
+use LAG\AdminBundle\Metadata\Attribute\Text;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class CollectionPropertyTest extends TestCase
+{
+    #[Test]
+    public function itReturnsDefaultProperties(): void
+    {
+        $collection = new Collection(name: 'tags');
+
+        self::assertSame('tags', $collection->getName());
+        self::assertSame('@LAGAdmin/grids/properties/collection.html.twig', $collection->getTemplate());
+        self::assertFalse($collection->isSortable());
+        self::assertNull($collection->getEntryProperty());
+    }
+
+    #[Test]
+    public function itReturnsImmutableCopyForWithEntryProperty(): void
+    {
+        $collection = new Collection(name: 'tags');
+        $entryProperty = new Text(name: 'name');
+
+        $new = $collection->withEntryProperty($entryProperty);
+        self::assertNotSame($collection, $new);
+        self::assertSame($entryProperty, $new->getEntryProperty());
+        self::assertNull($collection->getEntryProperty());
+    }
+}

--- a/tests/unit/Metadata/Attribute/CompoundTest.php
+++ b/tests/unit/Metadata/Attribute/CompoundTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\Metadata\Attribute;
+
+use LAG\AdminBundle\Metadata\Attribute\Compound;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class CompoundTest extends TestCase
+{
+    #[Test]
+    public function itReturnsDefaultProperties(): void
+    {
+        $compound = new Compound(name: 'fullName');
+
+        self::assertSame('fullName', $compound->getName());
+        self::assertFalse($compound->isSortable());
+        self::assertSame([], $compound->getProperties());
+    }
+
+    #[Test]
+    public function itReturnsImmutableCopyForWithProperties(): void
+    {
+        $compound = new Compound(name: 'fullName');
+
+        $new = $compound->withProperties(['firstName', 'lastName']);
+        self::assertNotSame($compound, $new);
+        self::assertSame(['firstName', 'lastName'], $new->getProperties());
+        self::assertSame([], $compound->getProperties());
+    }
+}

--- a/tests/unit/Metadata/Attribute/CountTest.php
+++ b/tests/unit/Metadata/Attribute/CountTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\Metadata\Attribute;
+
+use LAG\AdminBundle\Grid\DataTransformer\CountDataTransformer;
+use LAG\AdminBundle\Metadata\Attribute\Count;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class CountTest extends TestCase
+{
+    #[Test]
+    public function itReturnsDefaultProperties(): void
+    {
+        $count = new Count(name: 'reviewsCount');
+
+        self::assertSame('reviewsCount', $count->getName());
+        self::assertSame('@LAGAdmin/grids/properties/count.html.twig', $count->getTemplate());
+        self::assertTrue($count->isSortable());
+        self::assertSame(CountDataTransformer::class, $count->getDataTransformer());
+    }
+}

--- a/tests/unit/Metadata/Attribute/CreateTest.php
+++ b/tests/unit/Metadata/Attribute/CreateTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\Metadata\Attribute;
+
+use LAG\AdminBundle\Bridge\Doctrine\ORM\State\Processor\ORMProcessor;
+use LAG\AdminBundle\Metadata\Attribute\Create;
+use LAG\AdminBundle\State\Provider\CreateProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class CreateTest extends TestCase
+{
+    #[Test]
+    public function itReturnsDefaultProperties(): void
+    {
+        $operation = new Create();
+
+        self::assertSame('create', $operation->getShortName());
+        self::assertSame('@LAGAdmin/resources/create.html.twig', $operation->getTemplate());
+        self::assertSame(CreateProvider::class, $operation->getProvider());
+        self::assertSame(ORMProcessor::class, $operation->getProcessor());
+        self::assertSame(['POST', 'GET'], $operation->getMethods());
+        self::assertSame('lag_admin.ui.create_success', $operation->getSuccessMessage());
+    }
+}

--- a/tests/unit/Metadata/Attribute/DateTest.php
+++ b/tests/unit/Metadata/Attribute/DateTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\Metadata\Attribute;
+
+use LAG\AdminBundle\Metadata\Attribute\Date;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class DateTest extends TestCase
+{
+    #[Test]
+    public function itReturnsDefaultProperties(): void
+    {
+        $date = new Date(name: 'createdAt');
+
+        self::assertSame('createdAt', $date->getName());
+        self::assertSame('@LAGAdmin/grids/properties/date.html.twig', $date->getTemplate());
+        self::assertSame('medium', $date->getDateFormat());
+        self::assertSame('none', $date->getTimeFormat());
+    }
+
+    #[Test]
+    public function itReturnsImmutableCopiesForWithMethods(): void
+    {
+        $date = new Date(name: 'createdAt');
+
+        $new = $date->withDateFormat('short');
+        self::assertNotSame($date, $new);
+        self::assertSame('short', $new->getDateFormat());
+        self::assertSame('medium', $date->getDateFormat());
+
+        $new = $date->withTimeFormat('short');
+        self::assertNotSame($date, $new);
+        self::assertSame('short', $new->getTimeFormat());
+        self::assertSame('none', $date->getTimeFormat());
+    }
+}

--- a/tests/unit/Metadata/Attribute/DeleteTest.php
+++ b/tests/unit/Metadata/Attribute/DeleteTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\Metadata\Attribute;
+
+use LAG\AdminBundle\Bridge\Doctrine\ORM\State\Processor\ORMProcessor;
+use LAG\AdminBundle\Bridge\Doctrine\ORM\State\Provider\ORMProvider;
+use LAG\AdminBundle\Form\Type\Resource\DeleteType;
+use LAG\AdminBundle\Metadata\Attribute\Delete;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class DeleteTest extends TestCase
+{
+    #[Test]
+    public function itReturnsDefaultProperties(): void
+    {
+        $operation = new Delete();
+
+        self::assertSame('delete', $operation->getShortName());
+        self::assertSame('@LAGAdmin/resources/delete.html.twig', $operation->getTemplate());
+        self::assertSame(ORMProvider::class, $operation->getProvider());
+        self::assertSame(ORMProcessor::class, $operation->getProcessor());
+        self::assertSame(['POST', 'GET'], $operation->getMethods());
+        self::assertSame(DeleteType::class, $operation->getForm());
+        self::assertSame('lag_admin.ui.delete_success', $operation->getSuccessMessage());
+    }
+}

--- a/tests/unit/Metadata/Attribute/EntityFilterTest.php
+++ b/tests/unit/Metadata/Attribute/EntityFilterTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\Metadata\Attribute;
+
+use LAG\AdminBundle\Metadata\Attribute\EntityFilter;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+
+final class EntityFilterTest extends TestCase
+{
+    #[Test]
+    public function itReturnsDefaultProperties(): void
+    {
+        $filter = new EntityFilter(name: 'category');
+
+        self::assertSame('category', $filter->getName());
+        self::assertSame('=', $filter->getComparator());
+        self::assertSame('and', $filter->getOperator());
+        self::assertSame(EntityType::class, $filter->getFormType());
+        self::assertNull($filter->getProperty());
+        self::assertFalse($filter->isMultiple());
+    }
+
+    #[Test]
+    public function itReturnsImmutableCopiesForWithMethods(): void
+    {
+        $filter = new EntityFilter(name: 'category');
+
+        $new = $filter->withProperty('category.id');
+        self::assertNotSame($filter, $new);
+        self::assertSame('category.id', $new->getProperty());
+        self::assertNull($filter->getProperty());
+
+        $new = $filter->withMultiple(true);
+        self::assertNotSame($filter, $new);
+        self::assertTrue($new->isMultiple());
+        self::assertFalse($filter->isMultiple());
+    }
+}

--- a/tests/unit/Metadata/Attribute/FilterTest.php
+++ b/tests/unit/Metadata/Attribute/FilterTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\Metadata\Attribute;
+
+use LAG\AdminBundle\Metadata\Attribute\Filter;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
+final class FilterTest extends TestCase
+{
+    #[Test]
+    public function itReturnsDefaultProperties(): void
+    {
+        $filter = new Filter(name: 'search');
+
+        self::assertSame('search', $filter->getName());
+        self::assertSame('=', $filter->getComparator());
+        self::assertSame('and', $filter->getOperator());
+        self::assertSame(TextType::class, $filter->getFormType());
+        self::assertSame([], $filter->getFormOptions());
+    }
+
+    #[Test]
+    public function itReturnsImmutableCopiesForWithMethods(): void
+    {
+        $filter = new Filter(name: 'search');
+
+        $new = $filter->withName('title');
+        self::assertNotSame($filter, $new);
+        self::assertSame('title', $new->getName());
+        self::assertSame('search', $filter->getName());
+
+        $new = $filter->withComparator('like');
+        self::assertNotSame($filter, $new);
+        self::assertSame('like', $new->getComparator());
+
+        $new = $filter->withOperator('or');
+        self::assertNotSame($filter, $new);
+        self::assertSame('or', $new->getOperator());
+
+        $new = $filter->withFormType(\Symfony\Component\Form\Extension\Core\Type\IntegerType::class);
+        self::assertNotSame($filter, $new);
+        self::assertSame(\Symfony\Component\Form\Extension\Core\Type\IntegerType::class, $new->getFormType());
+
+        $new = $filter->withFormOptions(['attr' => ['placeholder' => 'Search...']]);
+        self::assertNotSame($filter, $new);
+        self::assertSame(['attr' => ['placeholder' => 'Search...']], $new->getFormOptions());
+    }
+}

--- a/tests/unit/Metadata/Attribute/FormPropertyTest.php
+++ b/tests/unit/Metadata/Attribute/FormPropertyTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\Metadata\Attribute;
+
+use LAG\AdminBundle\Grid\DataTransformer\FormDataTransformer;
+use LAG\AdminBundle\Metadata\Attribute\Form;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+
+final class FormPropertyTest extends TestCase
+{
+    #[Test]
+    public function itReturnsDefaultProperties(): void
+    {
+        $form = new Form(name: 'actions');
+
+        self::assertSame('actions', $form->getName());
+        self::assertSame('@LAGAdmin/grids/properties/form.html.twig', $form->getTemplate());
+        self::assertFalse($form->isSortable());
+        self::assertSame(FormDataTransformer::class, $form->getDataTransformer());
+        self::assertSame(FormType::class, $form->getForm());
+        self::assertNull($form->getFormTemplate());
+        self::assertSame([], $form->getFormOptions());
+        self::assertSame([], $form->getProperties());
+    }
+
+    #[Test]
+    public function itReturnsImmutableCopiesForWithMethods(): void
+    {
+        $form = new Form(name: 'actions');
+
+        $new = $form->setForm('App\Form\MyType');
+        self::assertNotSame($form, $new);
+        self::assertSame('App\Form\MyType', $new->getForm());
+        self::assertSame(FormType::class, $form->getForm());
+
+        $new = $form->setFormOptions(['csrf_protection' => false]);
+        self::assertNotSame($form, $new);
+        self::assertSame(['csrf_protection' => false], $new->getFormOptions());
+
+        $new = $form->withProperties(['field1', 'field2']);
+        self::assertNotSame($form, $new);
+        self::assertSame(['field1', 'field2'], $new->getProperties());
+
+        $new = $form->withFormTemplate('@App/form.html.twig');
+        self::assertNotSame($form, $new);
+        self::assertSame('@App/form.html.twig', $new->getFormTemplate());
+    }
+}

--- a/tests/unit/Metadata/Attribute/GridTest.php
+++ b/tests/unit/Metadata/Attribute/GridTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\Metadata\Attribute;
+
+use LAG\AdminBundle\Metadata\Attribute\Grid;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class GridTest extends TestCase
+{
+    #[Test]
+    public function itReturnsDefaultProperties(): void
+    {
+        $grid = new Grid(name: 'my_grid', properties: ['title']);
+
+        self::assertSame('my_grid', $grid->getName());
+        self::assertNull($grid->getTitle());
+        self::assertNull($grid->getType());
+        self::assertNull($grid->getTemplate());
+        self::assertSame('lag:table_grid', $grid->getComponent());
+        self::assertSame(['title'], $grid->getProperties());
+        self::assertSame([], $grid->getAttributes());
+        self::assertSame([], $grid->getRowAttributes());
+        self::assertSame([], $grid->getHeaderRowAttributes());
+        self::assertSame([], $grid->getHeaderAttributes());
+        self::assertSame([], $grid->getOptions());
+        self::assertSame([], $grid->getFormOptions());
+        self::assertNull($grid->getEmptyMessage());
+        self::assertFalse($grid->isSortable());
+        self::assertSame('sort', $grid->getSortParameter());
+        self::assertSame('order', $grid->getOrderParameter());
+        self::assertTrue($grid->useHeaders());
+    }
+
+    #[Test]
+    public function itHasNoPropertiesWhenEmpty(): void
+    {
+        $grid = new Grid(name: 'my_grid', properties: []);
+
+        self::assertFalse($grid->hasProperties());
+    }
+
+    #[Test]
+    public function itHasPropertiesWhenSet(): void
+    {
+        $grid = new Grid(name: 'my_grid', properties: ['title', 'author']);
+
+        self::assertTrue($grid->hasProperties());
+    }
+
+    #[Test]
+    public function itReturnsImmutableCopiesForWithMethods(): void
+    {
+        $grid = new Grid(name: 'my_grid', properties: ['title']);
+
+        $new = $grid->withName('other_grid');
+        self::assertNotSame($grid, $new);
+        self::assertSame('other_grid', $new->getName());
+        self::assertSame('my_grid', $grid->getName());
+
+        $new = $grid->withTitle('My Books');
+        self::assertNotSame($grid, $new);
+        self::assertSame('My Books', $new->getTitle());
+
+        $new = $grid->withType('card');
+        self::assertNotSame($grid, $new);
+        self::assertSame('card', $new->getType());
+
+        $new = $grid->withTemplate('@App/my_grid.html.twig');
+        self::assertNotSame($grid, $new);
+        self::assertSame('@App/my_grid.html.twig', $new->getTemplate());
+
+        $new = $grid->withComponent('lag:card_grid');
+        self::assertNotSame($grid, $new);
+        self::assertSame('lag:card_grid', $new->getComponent());
+
+        $new = $grid->withProperties(['author', 'title']);
+        self::assertNotSame($grid, $new);
+        self::assertSame(['author', 'title'], $new->getProperties());
+
+        $new = $grid->withAttributes(['class' => 'table table-striped']);
+        self::assertNotSame($grid, $new);
+        self::assertSame(['class' => 'table table-striped'], $new->getAttributes());
+
+        $new = $grid->withRowAttributes(['data-id' => 'id']);
+        self::assertNotSame($grid, $new);
+        self::assertSame(['data-id' => 'id'], $new->getRowAttributes());
+
+        $new = $grid->withHeaderRowAttributes(['class' => 'header']);
+        self::assertNotSame($grid, $new);
+        self::assertSame(['class' => 'header'], $new->getHeaderRowAttributes());
+
+        $new = $grid->withHeaderAttributes(['scope' => 'col']);
+        self::assertNotSame($grid, $new);
+        self::assertSame(['scope' => 'col'], $new->getHeaderAttributes());
+
+        $new = $grid->withOptions(['batch' => true]);
+        self::assertNotSame($grid, $new);
+        self::assertSame(['batch' => true], $new->getOptions());
+
+        $new = $grid->withFormOptions(['method' => 'GET']);
+        self::assertNotSame($grid, $new);
+        self::assertSame(['method' => 'GET'], $new->getFormOptions());
+
+        $new = $grid->withEmptyMessage('No books found');
+        self::assertNotSame($grid, $new);
+        self::assertSame('No books found', $new->getEmptyMessage());
+
+        $new = $grid->withSortable(true);
+        self::assertNotSame($grid, $new);
+        self::assertTrue($new->isSortable());
+
+        $new = $grid->withForm(null);
+        self::assertNotSame($grid, $new);
+        self::assertNull($new->getForm());
+
+        $new = $grid->withTitleAttributes(['class' => 'grid-title']);
+        self::assertNotSame($grid, $new);
+        self::assertSame(['class' => 'grid-title'], $new->getTitleAttributes());
+        self::assertSame([], $grid->getTitleAttributes());
+    }
+
+    #[Test]
+    public function itMutatesSortAndOrderParameters(): void
+    {
+        $grid = new Grid(name: 'my_grid', properties: ['title']);
+
+        $same = $grid->setSortParameter('s');
+        self::assertSame($grid, $same);
+        self::assertSame('s', $grid->getSortParameter());
+
+        $same = $grid->setOrderParameter('o');
+        self::assertSame($grid, $same);
+        self::assertSame('o', $grid->getOrderParameter());
+    }
+
+    #[Test]
+    public function itMutatesUseHeaders(): void
+    {
+        $grid = new Grid(name: 'my_grid', properties: ['title']);
+
+        $grid->setUseHeaders(false);
+        self::assertFalse($grid->useHeaders());
+    }
+}

--- a/tests/unit/Metadata/Attribute/GroupTest.php
+++ b/tests/unit/Metadata/Attribute/GroupTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\Metadata\Attribute;
+
+use LAG\AdminBundle\Metadata\Attribute\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class GroupTest extends TestCase
+{
+    #[Test]
+    public function itReturnsDefaultProperties(): void
+    {
+        $group = new Group(name: 'details');
+
+        self::assertSame('details', $group->getName());
+        self::assertSame('@LAGAdmin/grids/properties/group.html.twig', $group->getTemplate());
+        self::assertFalse($group->isSortable());
+        self::assertSame([], $group->getProperties());
+    }
+
+    #[Test]
+    public function itReturnsImmutableCopyForWithProperties(): void
+    {
+        $group = new Group(name: 'details');
+
+        $new = $group->withProperties(['firstName', 'lastName']);
+        self::assertNotSame($group, $new);
+        self::assertSame(['firstName', 'lastName'], $new->getProperties());
+        self::assertSame([], $group->getProperties());
+    }
+}

--- a/tests/unit/Metadata/Attribute/ImageTest.php
+++ b/tests/unit/Metadata/Attribute/ImageTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\Metadata\Attribute;
+
+use LAG\AdminBundle\Bridge\LiipImagine\DataTransformer\ImageDataTransformer;
+use LAG\AdminBundle\Metadata\Attribute\Image;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ImageTest extends TestCase
+{
+    #[Test]
+    public function itReturnsDefaultProperties(): void
+    {
+        $image = new Image(name: 'cover');
+
+        self::assertSame('cover', $image->getName());
+        self::assertSame('@LAGAdmin/grids/properties/image.html.twig', $image->getTemplate());
+        self::assertSame(ImageDataTransformer::class, $image->getDataTransformer());
+        self::assertFalse($image->isSortable());
+        self::assertNull($image->getImageFilter());
+        self::assertNull($image->getStorage());
+        self::assertTrue($image->getUpload());
+    }
+
+    #[Test]
+    public function itReturnsImmutableCopiesForWithMethods(): void
+    {
+        $image = new Image(name: 'cover');
+
+        $new = $image->withImageFilter('thumbnail_small');
+        self::assertNotSame($image, $new);
+        self::assertSame('thumbnail_small', $new->getImageFilter());
+        self::assertNull($image->getImageFilter());
+
+        $new = $image->withStorage('public');
+        self::assertNotSame($image, $new);
+        self::assertSame('public', $new->getStorage());
+        self::assertNull($image->getStorage());
+
+        $new = $image->withUpload(false);
+        self::assertNotSame($image, $new);
+        self::assertFalse($new->getUpload());
+        self::assertTrue($image->getUpload());
+    }
+}

--- a/tests/unit/Metadata/Attribute/LinkTest.php
+++ b/tests/unit/Metadata/Attribute/LinkTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\Metadata\Attribute;
+
+use LAG\AdminBundle\Metadata\Attribute\Link;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class LinkTest extends TestCase
+{
+    #[Test]
+    public function itReturnsDefaultProperties(): void
+    {
+        $link = new Link(name: 'edit', route: 'admin.book.update');
+
+        self::assertSame('edit', $link->getName());
+        self::assertNull($link->getTemplate());
+        self::assertSame('lag_admin:link', $link->getComponent());
+        self::assertFalse($link->isSortable());
+        self::assertSame('admin.book.update', $link->getRoute());
+        self::assertSame([], $link->getRouteParameters());
+        self::assertNull($link->getOperation());
+        self::assertNull($link->getType());
+        self::assertNull($link->getUrl());
+        self::assertNull($link->getText());
+        self::assertNull($link->getTextPath());
+        self::assertNull($link->getIcon());
+        self::assertNull($link->getWorkflow());
+        self::assertNull($link->getWorkflowTransition());
+    }
+
+    #[Test]
+    public function itReturnsImmutableCopiesForWithMethods(): void
+    {
+        $link = new Link(name: 'edit', route: 'admin.book.update');
+
+        $new = $link->withRoute('admin.book.show');
+        self::assertNotSame($link, $new);
+        self::assertSame('admin.book.show', $new->getRoute());
+        self::assertSame('admin.book.update', $link->getRoute());
+
+        $new = $link->withRouteParameters(['id' => 'id']);
+        self::assertNotSame($link, $new);
+        self::assertSame(['id' => 'id'], $new->getRouteParameters());
+
+        $new = $link->withOperation('update');
+        self::assertNotSame($link, $new);
+        self::assertSame('update', $new->getOperation());
+
+        $new = $link->withType('danger');
+        self::assertNotSame($link, $new);
+        self::assertSame('danger', $new->getType());
+
+        $new = $link->withUrl('https://example.com');
+        self::assertNotSame($link, $new);
+        self::assertSame('https://example.com', $new->getUrl());
+
+        $new = $link->withText('Edit');
+        self::assertNotSame($link, $new);
+        self::assertSame('Edit', $new->getText());
+
+        $new = $link->withTextPath('title');
+        self::assertNotSame($link, $new);
+        self::assertSame('title', $new->getTextPath());
+
+        $new = $link->withIcon('pencil');
+        self::assertNotSame($link, $new);
+        self::assertSame('pencil', $new->getIcon());
+
+        $new = $link->withWorkflow('publishing');
+        self::assertNotSame($link, $new);
+        self::assertSame('publishing', $new->getWorkflow());
+
+        $new = $link->withWorkflowTransition('publish');
+        self::assertNotSame($link, $new);
+        self::assertSame('publish', $new->getWorkflowTransition());
+    }
+}

--- a/tests/unit/Metadata/Attribute/MapTest.php
+++ b/tests/unit/Metadata/Attribute/MapTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\Metadata\Attribute;
+
+use LAG\AdminBundle\Metadata\Attribute\Map;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class MapTest extends TestCase
+{
+    #[Test]
+    public function itReturnsDefaultProperties(): void
+    {
+        $map = new Map(name: 'status', map: ['active' => 'Active', 'inactive' => 'Inactive']);
+
+        self::assertSame('status', $map->getName());
+        self::assertSame('@LAGAdmin/grids/properties/map.html.twig', $map->getTemplate());
+        self::assertSame(['active' => 'Active', 'inactive' => 'Inactive'], $map->getMap());
+    }
+
+    #[Test]
+    public function itReturnsImmutableCopyForWithMap(): void
+    {
+        $map = new Map(name: 'status', map: ['active' => 'Active']);
+
+        $new = $map->withMap(['enabled' => 'Enabled', 'disabled' => 'Disabled']);
+        self::assertNotSame($map, $new);
+        self::assertSame(['enabled' => 'Enabled', 'disabled' => 'Disabled'], $new->getMap());
+        self::assertSame(['active' => 'Active'], $map->getMap());
+    }
+}

--- a/tests/unit/Metadata/Attribute/OperationTest.php
+++ b/tests/unit/Metadata/Attribute/OperationTest.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\Metadata\Attribute;
+
+use LAG\AdminBundle\Exception\Exception;
+use LAG\AdminBundle\Exception\MissingOperationResourceException;
+use LAG\AdminBundle\Metadata\Attribute\Index;
+use LAG\AdminBundle\Metadata\Attribute\Resource;
+use LAG\AdminBundle\Metadata\Attribute\Show;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class OperationTest extends TestCase
+{
+    #[Test]
+    public function itReturnsDefaultShortName(): void
+    {
+        self::assertSame('index', (new Index())->getShortName());
+        self::assertSame('show', (new Show())->getShortName());
+    }
+
+    #[Test]
+    public function itThrowsWhenGettingNameWithoutResource(): void
+    {
+        $this->expectException(MissingOperationResourceException::class);
+        (new Index())->getName();
+    }
+
+    #[Test]
+    public function itReturnsNameAfterResourceIsSet(): void
+    {
+        $resource = new Resource(shortName: 'book', application: 'admin', resourceClass: \stdClass::class, operations: [new Index()]);
+        $operation = new Index();
+        $operation->setResource($resource);
+
+        self::assertSame('admin.book.index', $operation->getName());
+    }
+
+    #[Test]
+    public function itAllowsSettingSameResourceTwice(): void
+    {
+        $resource = new Resource(shortName: 'book', application: 'admin', resourceClass: \stdClass::class, operations: [new Index()]);
+        $operation = new Index();
+        $operation->setResource($resource);
+        $operation->setResource($resource);
+
+        self::assertSame('admin.book.index', $operation->getName());
+    }
+
+    #[Test]
+    public function itThrowsWhenChangingToDifferentResource(): void
+    {
+        $resource1 = new Resource(shortName: 'book', application: 'admin', resourceClass: \stdClass::class, operations: [new Index()]);
+        $resource2 = new Resource(shortName: 'author', application: 'admin', resourceClass: \stdClass::class, operations: [new Index()]);
+        $operation = new Index();
+        $operation->setResource($resource1);
+
+        $this->expectException(Exception::class);
+        $operation->setResource($resource2);
+    }
+
+    #[Test]
+    public function itReturnsImmutableCopiesForWithMethods(): void
+    {
+        $operation = new Index();
+
+        $new = $operation->withShortName('custom_index');
+        self::assertNotSame($operation, $new);
+        self::assertSame('custom_index', $new->getShortName());
+        self::assertSame('index', $operation->getShortName());
+
+        $new = $operation->withTitle('My Title');
+        self::assertNotSame($operation, $new);
+        self::assertSame('My Title', $new->getTitle());
+        self::assertNull($operation->getTitle());
+
+        $new = $operation->withRoute('admin.book.index');
+        self::assertNotSame($operation, $new);
+        self::assertSame('admin.book.index', $new->getRoute());
+        self::assertNull($operation->getRoute());
+
+        $new = $operation->withPath('/books/index');
+        self::assertNotSame($operation, $new);
+        self::assertSame('/books/index', $new->getPath());
+
+        $new = $operation->withPermissions(['ROLE_ADMIN']);
+        self::assertNotSame($operation, $new);
+        self::assertSame(['ROLE_ADMIN'], $new->getRoles());
+
+        $new = $operation->withBaseTemplate('@LAGAdmin/base.html.twig');
+        self::assertNotSame($operation, $new);
+        self::assertSame('@LAGAdmin/base.html.twig', $new->getBaseTemplate());
+
+        $new = $operation->withIdentifiers(['id']);
+        self::assertNotSame($operation, $new);
+        self::assertSame(['id'], $new->getIdentifiers());
+
+        $new = $operation->withRouteParameters(['id' => 'id']);
+        self::assertNotSame($operation, $new);
+        self::assertSame(['id' => 'id'], $new->getRouteParameters());
+
+        $new = $operation->withRedirectRoute('admin.book.index');
+        self::assertNotSame($operation, $new);
+        self::assertSame('admin.book.index', $new->getRedirectRoute());
+
+        $new = $operation->withRedirectOperation('index');
+        self::assertNotSame($operation, $new);
+        self::assertSame('index', $new->getRedirectOperation());
+
+        $new = $operation->withValidation(false);
+        self::assertNotSame($operation, $new);
+        self::assertFalse($new->hasValidation());
+
+        $new = $operation->withAjax(false);
+        self::assertNotSame($operation, $new);
+        self::assertFalse($new->hasAjax());
+    }
+
+    #[Test]
+    public function itReturnsFormOptionByKey(): void
+    {
+        $operation = (new Index())->withFormOptions(['csrf_protection' => false]);
+
+        self::assertFalse($operation->getFormOption('csrf_protection'));
+        self::assertNull($operation->getFormOption('missing_key'));
+    }
+
+    #[Test]
+    public function itAddsASingleFormOption(): void
+    {
+        $operation = (new Index())->withFormOption('csrf_protection', false);
+
+        self::assertFalse($operation->getFormOption('csrf_protection'));
+    }
+
+    #[Test]
+    public function itThrowsWhenGettingResourceNotSet(): void
+    {
+        $this->expectException(Exception::class);
+        (new Index())->getResource();
+    }
+
+    #[Test]
+    public function itReturnsResourceAfterItIsSet(): void
+    {
+        $resource = new Resource(shortName: 'book', application: 'admin', resourceClass: \stdClass::class, operations: [new Index()]);
+        $operation = new Index();
+        $operation->setResource($resource);
+
+        self::assertSame($resource, $operation->getResource());
+    }
+
+    #[Test]
+    public function itReturnsImmutableCopiesForRemainingWithMethods(): void
+    {
+        $operation = new Index();
+
+        $new = $operation->withContext(['locale' => 'fr']);
+        self::assertNotSame($operation, $new);
+        self::assertSame(['locale' => 'fr'], $new->getContext());
+        self::assertSame([], $operation->getContext());
+
+        $new = $operation->withDescription('List all books');
+        self::assertNotSame($operation, $new);
+        self::assertSame('List all books', $new->getDescription());
+        self::assertNull($operation->getDescription());
+
+        $new = $operation->withIcon('list');
+        self::assertNotSame($operation, $new);
+        self::assertSame('list', $new->getIcon());
+        self::assertNull($operation->getIcon());
+
+        $new = $operation->withTemplate('@App/index.html.twig');
+        self::assertNotSame($operation, $new);
+        self::assertSame('@App/index.html.twig', $new->getTemplate());
+
+        $new = $operation->withController('App\Controller\BookController');
+        self::assertNotSame($operation, $new);
+        self::assertSame('App\Controller\BookController', $new->getController());
+
+        $new = $operation->withRedirectRouteParameters(['id' => 'id']);
+        self::assertNotSame($operation, $new);
+        self::assertSame(['id' => 'id'], $new->getRedirectRouteParameters());
+
+        $new = $operation->withForm('App\Form\BookType');
+        self::assertNotSame($operation, $new);
+        self::assertSame('App\Form\BookType', $new->getForm());
+
+        $new = $operation->withFormOptions(['csrf_protection' => false]);
+        self::assertNotSame($operation, $new);
+        self::assertSame(['csrf_protection' => false], $new->getFormOptions());
+
+        $new = $operation->withFormTemplate('@App/form.html.twig');
+        self::assertNotSame($operation, $new);
+        self::assertSame('@App/form.html.twig', $new->getFormTemplate());
+
+        $new = $operation->withProcessor('App\State\Processor\BookProcessor');
+        self::assertNotSame($operation, $new);
+        self::assertSame('App\State\Processor\BookProcessor', $new->getProcessor());
+
+        $new = $operation->withProvider('App\State\Provider\BookProvider');
+        self::assertNotSame($operation, $new);
+        self::assertSame('App\State\Provider\BookProvider', $new->getProvider());
+
+        $new = $operation->withMethods(['GET']);
+        self::assertNotSame($operation, $new);
+        self::assertSame(['GET'], $new->getMethods());
+
+        $new = $operation->withContextualLinks([]);
+        self::assertNotSame($operation, $new);
+        self::assertSame([], $new->getContextualLinks());
+
+        $new = $operation->withItemLinks([]);
+        self::assertNotSame($operation, $new);
+        self::assertSame([], $new->getItemLinks());
+
+        $new = $operation->withValidationContext(['groups' => ['Default']]);
+        self::assertNotSame($operation, $new);
+        self::assertSame(['groups' => ['Default']], $new->getValidationContext());
+
+        $new = $operation->withNormalizationContext(['groups' => ['read']]);
+        self::assertNotSame($operation, $new);
+        self::assertSame(['groups' => ['read']], $new->getNormalizationContext());
+
+        $new = $operation->withDenormalizationContext(['groups' => ['write']]);
+        self::assertNotSame($operation, $new);
+        self::assertSame(['groups' => ['write']], $new->getDenormalizationContext());
+
+        $new = $operation->withInput('App\Dto\BookInput');
+        self::assertNotSame($operation, $new);
+        self::assertSame('App\Dto\BookInput', $new->getInput());
+
+        $new = $operation->withOutput('App\Dto\BookOutput');
+        self::assertNotSame($operation, $new);
+        self::assertSame('App\Dto\BookOutput', $new->getOutput());
+
+        $new = $operation->withWorkflow('publishing');
+        self::assertNotSame($operation, $new);
+        self::assertSame('publishing', $new->getWorkflow());
+
+        $new = $operation->withWorkflowTransition('publish');
+        self::assertNotSame($operation, $new);
+        self::assertSame('publish', $new->getWorkflowTransition());
+
+        $new = $operation->withEmbedded(true);
+        self::assertNotSame($operation, $new);
+        self::assertTrue($new->isEmbedded());
+        self::assertFalse($operation->isEmbedded());
+
+        $new = $operation->withSuccessMessage('Book saved!');
+        self::assertNotSame($operation, $new);
+        self::assertSame('Book saved!', $new->getSuccessMessage());
+    }
+}

--- a/tests/unit/Metadata/Attribute/PropertyTest.php
+++ b/tests/unit/Metadata/Attribute/PropertyTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\Metadata\Attribute;
+
+use LAG\AdminBundle\Metadata\Attribute\Property;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class PropertyTest extends TestCase
+{
+    #[Test]
+    public function itReturnsDefaultValues(): void
+    {
+        $property = new Property(name: 'title');
+
+        self::assertSame('title', $property->getName());
+        self::assertNull($property->getPropertyPath());
+        self::assertNull($property->getLabel());
+        self::assertNull($property->getTemplate());
+        self::assertTrue($property->isSortable());
+        self::assertFalse($property->isTranslatable());
+        self::assertSame([], $property->getAttributes());
+        self::assertSame([], $property->getRowAttributes());
+        self::assertSame([], $property->getHeaderAttributes());
+        self::assertNull($property->getDataTransformer());
+        self::assertNull($property->getRoles());
+        self::assertNull($property->getCondition());
+        self::assertNull($property->getSortingPath());
+    }
+
+    #[Test]
+    public function itReturnsAttributeByKey(): void
+    {
+        $property = (new Property(name: 'title'))->withAttribute('class', 'bold');
+
+        self::assertSame('bold', $property->getAttribute('class'));
+        self::assertNull($property->getAttribute('missing'));
+    }
+
+    #[Test]
+    public function itReturnsImmutableCopiesForWithMethods(): void
+    {
+        $property = new Property(name: 'title');
+
+        $new = $property->withName('author');
+        self::assertNotSame($property, $new);
+        self::assertSame('author', $new->getName());
+        self::assertSame('title', $property->getName());
+
+        $new = $property->withLabel('Book Title');
+        self::assertNotSame($property, $new);
+        self::assertSame('Book Title', $new->getLabel());
+
+        $new = $property->withPropertyPath('book.title');
+        self::assertNotSame($property, $new);
+        self::assertSame('book.title', $new->getPropertyPath());
+
+        $new = $property->withTemplate('@App/cell.html.twig');
+        self::assertNotSame($property, $new);
+        self::assertSame('@App/cell.html.twig', $new->getTemplate());
+
+        $new = $property->withSortable(false);
+        self::assertNotSame($property, $new);
+        self::assertFalse($new->isSortable());
+
+        $new = $property->withTranslatable(true);
+        self::assertNotSame($property, $new);
+        self::assertTrue($new->isTranslatable());
+
+        $new = $property->withAttributes(['class' => 'text-bold']);
+        self::assertNotSame($property, $new);
+        self::assertSame(['class' => 'text-bold'], $new->getAttributes());
+
+        $new = $property->withRowAttributes(['class' => 'row']);
+        self::assertNotSame($property, $new);
+        self::assertSame(['class' => 'row'], $new->getRowAttributes());
+
+        $new = $property->withHeaderAttributes(['scope' => 'col']);
+        self::assertNotSame($property, $new);
+        self::assertSame(['scope' => 'col'], $new->getHeaderAttributes());
+
+        $new = $property->withDataTransformer('App\DataTransformer\MyTransformer');
+        self::assertNotSame($property, $new);
+        self::assertSame('App\DataTransformer\MyTransformer', $new->getDataTransformer());
+
+        $new = $property->withPermissions(['ROLE_ADMIN']);
+        self::assertNotSame($property, $new);
+        self::assertSame(['ROLE_ADMIN'], $new->getRoles());
+
+        $new = $property->withCondition('workflow.active');
+        self::assertNotSame($property, $new);
+        self::assertSame('workflow.active', $new->getCondition());
+
+        $new = $property->withSortingPath('title');
+        self::assertNotSame($property, $new);
+        self::assertSame('title', $new->getSortingPath());
+
+        $new = $property->withAttribute('id', 'my-prop');
+        self::assertNotSame($property, $new);
+        self::assertSame('my-prop', $new->getAttribute('id'));
+    }
+}

--- a/tests/unit/Metadata/Attribute/ResourceLinkTest.php
+++ b/tests/unit/Metadata/Attribute/ResourceLinkTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\Metadata\Attribute;
+
+use LAG\AdminBundle\Metadata\Attribute\ResourceLink;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ResourceLinkTest extends TestCase
+{
+    #[Test]
+    public function itReturnsDefaultProperties(): void
+    {
+        $link = new ResourceLink(name: 'author');
+
+        self::assertSame('author', $link->getName());
+        self::assertSame('@LAGAdmin/grids/properties/text.html.twig', $link->getTemplate());
+        self::assertTrue($link->isSortable());
+        self::assertNull($link->getApplication());
+        self::assertNull($link->getResource());
+        self::assertNull($link->getOperation());
+    }
+
+    #[Test]
+    public function itReturnsImmutableCopiesForWithMethods(): void
+    {
+        $link = new ResourceLink(name: 'author');
+
+        $new = $link->withApplication('admin');
+        self::assertNotSame($link, $new);
+        self::assertSame('admin', $new->getApplication());
+        self::assertNull($link->getApplication());
+
+        $new = $link->withResource('author');
+        self::assertNotSame($link, $new);
+        self::assertSame('author', $new->getResource());
+
+        $new = $link->withOperation('show');
+        self::assertNotSame($link, $new);
+        self::assertSame('show', $new->getOperation());
+    }
+}

--- a/tests/unit/Metadata/Attribute/ResourceTest.php
+++ b/tests/unit/Metadata/Attribute/ResourceTest.php
@@ -1,0 +1,351 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\Metadata\Attribute;
+
+use LAG\AdminBundle\Exception\Exception;
+use LAG\AdminBundle\Exception\OperationMissingException;
+use LAG\AdminBundle\Exception\Resource\MissingResourceNameException;
+use LAG\AdminBundle\Metadata\Attribute\Create;
+use LAG\AdminBundle\Metadata\Attribute\Date;
+use LAG\AdminBundle\Metadata\Attribute\Index;
+use LAG\AdminBundle\Metadata\Attribute\Resource;
+use LAG\AdminBundle\Metadata\Attribute\Show;
+use LAG\AdminBundle\Metadata\Attribute\Text;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ResourceTest extends TestCase
+{
+    #[Test]
+    public function itThrowsWhenGettingNameWithNullShortName(): void
+    {
+        $resource = new Resource(application: 'admin', resourceClass: \stdClass::class, operations: [new Index()]);
+
+        $this->expectException(MissingResourceNameException::class);
+        $resource->getName();
+    }
+
+    #[Test]
+    public function itReturnsNameAsApplicationDotShortName(): void
+    {
+        $resource = new Resource(shortName: 'book', application: 'admin', resourceClass: \stdClass::class, operations: [new Index()]);
+
+        self::assertSame('admin.book', $resource->getName());
+    }
+
+    #[Test]
+    public function itChecksWhetherOperationExists(): void
+    {
+        $resource = new Resource(
+            shortName: 'book',
+            application: 'admin',
+            resourceClass: \stdClass::class,
+            operations: [new Index(), new Show()],
+        );
+
+        self::assertTrue($resource->hasOperation('index'));
+        self::assertTrue($resource->hasOperation('show'));
+        self::assertFalse($resource->hasOperation('create'));
+    }
+
+    #[Test]
+    public function itThrowsWhenGettingMissingOperation(): void
+    {
+        $resource = new Resource(shortName: 'book', application: 'admin', resourceClass: \stdClass::class, operations: [new Index()]);
+
+        $this->expectException(OperationMissingException::class);
+        $resource->getOperation('show');
+    }
+
+    #[Test]
+    public function itGetsOperationByShortName(): void
+    {
+        $resource = new Resource(
+            shortName: 'book',
+            application: 'admin',
+            resourceClass: \stdClass::class,
+            operations: [new Index(), new Show()],
+        );
+
+        self::assertSame('index', $resource->getOperation('index')->getShortName());
+        self::assertSame('show', $resource->getOperation('show')->getShortName());
+    }
+
+    #[Test]
+    public function itFiltersCollectionOperations(): void
+    {
+        $index = new Index();
+        $show = new Show();
+        $create = new Create();
+        $resource = new Resource(
+            shortName: 'book',
+            application: 'admin',
+            resourceClass: \stdClass::class,
+            operations: [$index, $show, $create],
+        );
+
+        $collectionOps = $resource->getCollectionOperations();
+
+        self::assertCount(1, $collectionOps);
+        self::assertContains($index, $collectionOps);
+        self::assertNotContains($show, $collectionOps);
+        self::assertNotContains($create, $collectionOps);
+    }
+
+    #[Test]
+    public function itChecksWhetherPropertyExists(): void
+    {
+        $resource = new Resource(
+            shortName: 'book',
+            application: 'admin',
+            resourceClass: \stdClass::class,
+            operations: [new Index()],
+            properties: [new Text('title')],
+        );
+
+        self::assertTrue($resource->hasProperty('title'));
+        self::assertFalse($resource->hasProperty('author'));
+    }
+
+    #[Test]
+    public function itThrowsWhenGettingMissingProperty(): void
+    {
+        $resource = new Resource(shortName: 'book', application: 'admin', resourceClass: \stdClass::class, operations: [new Index()]);
+
+        $this->expectException(Exception::class);
+        $resource->getProperty('title');
+    }
+
+    #[Test]
+    public function itGetsPropertyByName(): void
+    {
+        $title = new Text('title');
+        $resource = new Resource(
+            shortName: 'book',
+            application: 'admin',
+            resourceClass: \stdClass::class,
+            operations: [new Index()],
+            properties: [$title],
+        );
+
+        self::assertSame($title, $resource->getProperty('title'));
+    }
+
+    #[Test]
+    public function itIndexesPropertiesByName(): void
+    {
+        $title = new Text('title');
+        $author = new Text('author');
+        $resource = new Resource(
+            shortName: 'book',
+            application: 'admin',
+            resourceClass: \stdClass::class,
+            operations: [new Index()],
+            properties: [$title, $author],
+        );
+        $properties = $resource->getProperties();
+
+        self::assertArrayHasKey('title', $properties);
+        self::assertArrayHasKey('author', $properties);
+        self::assertTrue($resource->hasProperties());
+    }
+
+    #[Test]
+    public function itHasNoPropertiesWhenEmpty(): void
+    {
+        $resource = new Resource(shortName: 'book', application: 'admin', resourceClass: \stdClass::class, operations: [new Index()]);
+
+        self::assertFalse($resource->hasProperties());
+    }
+
+    #[Test]
+    public function itReturnsImmutableCopiesForWithMethods(): void
+    {
+        $resource = new Resource(shortName: 'book', application: 'admin', resourceClass: \stdClass::class, operations: [new Index()]);
+
+        $new = $resource->withShortName('article');
+        self::assertNotSame($resource, $new);
+        self::assertSame('article', $new->getShortName());
+        self::assertSame('book', $resource->getShortName());
+
+        $new = $resource->withApplication('shop');
+        self::assertNotSame($resource, $new);
+        self::assertSame('shop', $new->getApplication());
+
+        $new = $resource->withResourceClass(\stdClass::class);
+        self::assertNotSame($resource, $new);
+
+        $new = $resource->withTitle('Books');
+        self::assertNotSame($resource, $new);
+        self::assertSame('Books', $new->getTitle());
+
+        $new = $resource->withPermissions(['ROLE_ADMIN']);
+        self::assertNotSame($resource, $new);
+        self::assertSame(['ROLE_ADMIN'], $new->getPermissions());
+
+        $new = $resource->withIdentifiers(['uuid']);
+        self::assertNotSame($resource, $new);
+        self::assertSame(['uuid'], $new->getIdentifiers());
+
+        $new = $resource->withValidation(false);
+        self::assertNotSame($resource, $new);
+        self::assertFalse($new->hasValidation());
+
+        $new = $resource->withAjax(false);
+        self::assertNotSame($resource, $new);
+        self::assertFalse($new->hasAjax());
+    }
+
+    #[Test]
+    public function itReturnsResourceClass(): void
+    {
+        $resource = new Resource(shortName: 'book', application: 'admin', resourceClass: \stdClass::class, operations: [new Index()]);
+
+        self::assertSame(\stdClass::class, $resource->getResourceClass());
+    }
+
+    #[Test]
+    public function itReturnsAllOperations(): void
+    {
+        $index = new Index();
+        $show = new Show();
+        $resource = new Resource(
+            shortName: 'book',
+            application: 'admin',
+            resourceClass: \stdClass::class,
+            operations: [$index, $show],
+        );
+
+        $operations = $resource->getOperations();
+        self::assertCount(2, $operations);
+    }
+
+    #[Test]
+    public function itReplacesOperationsViaWithOperations(): void
+    {
+        $resource = new Resource(shortName: 'book', application: 'admin', resourceClass: \stdClass::class, operations: [new Index()]);
+
+        $new = $resource->withOperations([new Show()]);
+        self::assertNotSame($resource, $new);
+        self::assertTrue($new->hasOperation('show'));
+        self::assertFalse($new->hasOperation('index'));
+    }
+
+    #[Test]
+    public function itFiltersPropertiesByType(): void
+    {
+        $title = new Text('title');
+        $createdAt = new Date('createdAt');
+        $resource = new Resource(
+            shortName: 'book',
+            application: 'admin',
+            resourceClass: \stdClass::class,
+            operations: [new Index()],
+            properties: [$title, $createdAt],
+        );
+
+        $textProperties = $resource->getPropertiesByType(Text::class);
+        self::assertNotEmpty($textProperties);
+        foreach ($textProperties as $property) {
+            self::assertInstanceOf(Text::class, $property);
+        }
+
+        $dateProperties = $resource->getPropertiesByType(Date::class);
+        self::assertNotEmpty($dateProperties);
+        foreach ($dateProperties as $property) {
+            self::assertInstanceOf(Date::class, $property);
+        }
+    }
+
+    #[Test]
+    public function itReplacesPropertiesViaWithProperties(): void
+    {
+        $resource = new Resource(
+            shortName: 'book',
+            application: 'admin',
+            resourceClass: \stdClass::class,
+            operations: [new Index()],
+            properties: [new Text('title')],
+        );
+
+        $author = new Text('author');
+        $new = $resource->withProperties([$author]);
+        self::assertNotSame($resource, $new);
+        self::assertTrue($new->hasProperty('author'));
+        self::assertFalse($new->hasProperty('title'));
+    }
+
+    #[Test]
+    public function itReturnsImmutableCopiesForRemainingWithMethods(): void
+    {
+        $resource = new Resource(shortName: 'book', application: 'admin', resourceClass: \stdClass::class, operations: [new Index()]);
+
+        $new = $resource->withGroup('catalog');
+        self::assertNotSame($resource, $new);
+        self::assertSame('catalog', $new->getGroup());
+        self::assertNull($resource->getGroup());
+
+        $new = $resource->withIcon('book');
+        self::assertNotSame($resource, $new);
+        self::assertSame('book', $new->getIcon());
+        self::assertNull($resource->getIcon());
+
+        $new = $resource->withProcessor('App\State\Processor\BookProcessor');
+        self::assertNotSame($resource, $new);
+        self::assertSame('App\State\Processor\BookProcessor', $new->getProcessor());
+
+        $new = $resource->withProvider('App\State\Provider\BookProvider');
+        self::assertNotSame($resource, $new);
+        self::assertSame('App\State\Provider\BookProvider', $new->getProvider());
+
+        $new = $resource->withRoutePattern('{resource}.{operation}');
+        self::assertNotSame($resource, $new);
+        self::assertSame('{resource}.{operation}', $new->getRoutePattern());
+
+        $new = $resource->withPathPrefix('/admin');
+        self::assertNotSame($resource, $new);
+        self::assertSame('/admin', $new->getPathPrefix());
+
+        $new = $resource->withTranslationPattern('{resource}.{message}');
+        self::assertNotSame($resource, $new);
+        self::assertSame('{resource}.{message}', $new->getTranslationPattern());
+
+        $new = $resource->withTranslationDomain('admin');
+        self::assertNotSame($resource, $new);
+        self::assertSame('admin', $new->getTranslationDomain());
+
+        $new = $resource->withForm('App\Form\BookType');
+        self::assertNotSame($resource, $new);
+        self::assertSame('App\Form\BookType', $new->getForm());
+
+        $new = $resource->withFormOptions(['csrf_protection' => false]);
+        self::assertNotSame($resource, $new);
+        self::assertSame(['csrf_protection' => false], $new->getFormOptions());
+
+        $new = $resource->withFormTemplate('@App/form.html.twig');
+        self::assertNotSame($resource, $new);
+        self::assertSame('@App/form.html.twig', $new->getFormTemplate());
+
+        $new = $resource->withValidationContext(['groups' => ['Default']]);
+        self::assertNotSame($resource, $new);
+        self::assertSame(['groups' => ['Default']], $new->getValidationContext());
+
+        $new = $resource->withNormalizationContext(['groups' => ['read']]);
+        self::assertNotSame($resource, $new);
+        self::assertSame(['groups' => ['read']], $new->getNormalizationContext());
+
+        $new = $resource->withDenormalizationContext(['groups' => ['write']]);
+        self::assertNotSame($resource, $new);
+        self::assertSame(['groups' => ['write']], $new->getDenormalizationContext());
+
+        $new = $resource->withInput('App\Dto\BookInput');
+        self::assertNotSame($resource, $new);
+        self::assertSame('App\Dto\BookInput', $new->getInput());
+
+        $new = $resource->withOutput('App\Dto\BookOutput');
+        self::assertNotSame($resource, $new);
+        self::assertSame('App\Dto\BookOutput', $new->getOutput());
+    }
+}

--- a/tests/unit/Metadata/Attribute/RichTextTest.php
+++ b/tests/unit/Metadata/Attribute/RichTextTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\Metadata\Attribute;
+
+use LAG\AdminBundle\Metadata\Attribute\RichText;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class RichTextTest extends TestCase
+{
+    #[Test]
+    public function itReturnsDefaultProperties(): void
+    {
+        $richText = new RichText(name: 'content');
+
+        self::assertSame('content', $richText->getName());
+        self::assertSame('@LAGAdmin/grids/properties/rich_text.html.twig', $richText->getTemplate());
+        self::assertFalse($richText->isSortable());
+        self::assertSame(100, $richText->getLength());
+        self::assertSame('...', $richText->getReplace());
+        self::assertSame('~', $richText->getEmpty());
+        self::assertSame('', $richText->getSuffix());
+        self::assertSame('', $richText->getPrefix());
+    }
+
+    #[Test]
+    public function itReturnsImmutableCopiesForWithMethods(): void
+    {
+        $richText = new RichText(name: 'content');
+
+        $new = $richText->withLength(200);
+        self::assertNotSame($richText, $new);
+        self::assertSame(200, $new->getLength());
+
+        $new = $richText->withReplace('…');
+        self::assertNotSame($richText, $new);
+        self::assertSame('…', $new->getReplace());
+
+        $new = $richText->withEmpty('-');
+        self::assertNotSame($richText, $new);
+        self::assertSame('-', $new->getEmpty());
+
+        $new = $richText->setSuffix(' (read more)');
+        self::assertNotSame($richText, $new);
+        self::assertSame(' (read more)', $new->getSuffix());
+
+        $new = $richText->setPrefix('> ');
+        self::assertNotSame($richText, $new);
+        self::assertSame('> ', $new->getPrefix());
+    }
+}

--- a/tests/unit/Metadata/Attribute/SlugTest.php
+++ b/tests/unit/Metadata/Attribute/SlugTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\Metadata\Attribute;
+
+use LAG\AdminBundle\Metadata\Attribute\Slug;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class SlugTest extends TestCase
+{
+    #[Test]
+    public function itReturnsDefaultProperties(): void
+    {
+        $slug = new Slug(name: 'slug');
+
+        self::assertSame('slug', $slug->getName());
+        self::assertSame('@LAGAdmin/grids/properties/slug.html.twig', $slug->getTemplate());
+        self::assertSame(['name'], $slug->getSource());
+        self::assertSame('default', $slug->getSlugger());
+    }
+
+    #[Test]
+    public function itReturnsImmutableCopiesForWithMethods(): void
+    {
+        $slug = new Slug(name: 'slug');
+
+        $new = $slug->withSource('title');
+        self::assertNotSame($slug, $new);
+        self::assertSame(['title'], $new->getSource());
+        self::assertSame(['name'], $slug->getSource());
+
+        $new = $slug->withSlugger('ascii');
+        self::assertNotSame($slug, $new);
+        self::assertSame('ascii', $new->getSlugger());
+        self::assertSame('default', $slug->getSlugger());
+    }
+}

--- a/tests/unit/Metadata/Attribute/TextFilterTest.php
+++ b/tests/unit/Metadata/Attribute/TextFilterTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\Metadata\Attribute;
+
+use LAG\AdminBundle\Metadata\Attribute\TextFilter;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
+final class TextFilterTest extends TestCase
+{
+    #[Test]
+    public function itReturnsDefaultProperties(): void
+    {
+        $filter = new TextFilter(name: 'search');
+
+        self::assertSame('search', $filter->getName());
+        self::assertSame('like', $filter->getComparator());
+        self::assertSame('and', $filter->getOperator());
+        self::assertSame(TextType::class, $filter->getFormType());
+        self::assertNull($filter->getProperties());
+    }
+
+    #[Test]
+    public function itReturnsImmutableCopiesForWithMethods(): void
+    {
+        $filter = new TextFilter(name: 'search');
+
+        $new = $filter->withProperties(['title', 'description']);
+        self::assertNotSame($filter, $new);
+        self::assertSame(['title', 'description'], $new->getProperties());
+        self::assertNull($filter->getProperties());
+    }
+}

--- a/tests/unit/Metadata/Attribute/TextTest.php
+++ b/tests/unit/Metadata/Attribute/TextTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\Metadata\Attribute;
+
+use LAG\AdminBundle\Metadata\Attribute\Text;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class TextTest extends TestCase
+{
+    #[Test]
+    public function itReturnsDefaultProperties(): void
+    {
+        $text = new Text(name: 'title');
+
+        self::assertSame('title', $text->getName());
+        self::assertSame('@LAGAdmin/grids/properties/text.html.twig', $text->getTemplate());
+        self::assertTrue($text->isSortable());
+        self::assertSame(100, $text->getLength());
+        self::assertSame('...', $text->getReplace());
+        self::assertSame('~', $text->getEmpty());
+        self::assertSame('', $text->getSuffix());
+        self::assertSame('', $text->getPrefix());
+    }
+
+    #[Test]
+    public function itReturnsImmutableCopiesForWithMethods(): void
+    {
+        $text = new Text(name: 'title');
+
+        $new = $text->withLength(50);
+        self::assertNotSame($text, $new);
+        self::assertSame(50, $new->getLength());
+        self::assertSame(100, $text->getLength());
+
+        $new = $text->withReplace('…');
+        self::assertNotSame($text, $new);
+        self::assertSame('…', $new->getReplace());
+
+        $new = $text->withEmpty('-');
+        self::assertNotSame($text, $new);
+        self::assertSame('-', $new->getEmpty());
+
+        $new = $text->setSuffix(' EUR');
+        self::assertNotSame($text, $new);
+        self::assertSame(' EUR', $new->getSuffix());
+
+        $new = $text->setPrefix('$ ');
+        self::assertNotSame($text, $new);
+        self::assertSame('$ ', $new->getPrefix());
+    }
+}

--- a/tests/unit/Metadata/Attribute/TitleTest.php
+++ b/tests/unit/Metadata/Attribute/TitleTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\Metadata\Attribute;
+
+use LAG\AdminBundle\Metadata\Attribute\Title;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class TitleTest extends TestCase
+{
+    #[Test]
+    public function itReturnsDefaultProperties(): void
+    {
+        $title = new Title(name: 'title');
+
+        self::assertSame('title', $title->getName());
+        self::assertSame('@LAGAdmin/grids/properties/title.html.twig', $title->getTemplate());
+        self::assertFalse($title->isSortable());
+        self::assertSame(100, $title->getLength());
+        self::assertSame('...', $title->getReplace());
+        self::assertSame('~', $title->getEmpty());
+        self::assertSame('', $title->getSuffix());
+        self::assertSame('', $title->getPrefix());
+    }
+
+    #[Test]
+    public function itReturnsImmutableCopiesForWithMethods(): void
+    {
+        $title = new Title(name: 'title');
+
+        $new = $title->withLength(50);
+        self::assertNotSame($title, $new);
+        self::assertSame(50, $new->getLength());
+
+        $new = $title->withReplace('…');
+        self::assertNotSame($title, $new);
+        self::assertSame('…', $new->getReplace());
+
+        $new = $title->withEmpty('-');
+        self::assertNotSame($title, $new);
+        self::assertSame('-', $new->getEmpty());
+
+        $new = $title->setSuffix(' (new)');
+        self::assertNotSame($title, $new);
+        self::assertSame(' (new)', $new->getSuffix());
+
+        $new = $title->setPrefix('[');
+        self::assertNotSame($title, $new);
+        self::assertSame('[', $new->getPrefix());
+    }
+}

--- a/tests/unit/Metadata/Attribute/UpdateTest.php
+++ b/tests/unit/Metadata/Attribute/UpdateTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\Metadata\Attribute;
+
+use LAG\AdminBundle\Bridge\Doctrine\ORM\State\Processor\ORMProcessor;
+use LAG\AdminBundle\Bridge\Doctrine\ORM\State\Provider\ORMProvider;
+use LAG\AdminBundle\Metadata\Attribute\Update;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class UpdateTest extends TestCase
+{
+    #[Test]
+    public function itReturnsDefaultProperties(): void
+    {
+        $operation = new Update();
+
+        self::assertSame('update', $operation->getShortName());
+        self::assertSame('@LAGAdmin/resources/update.html.twig', $operation->getTemplate());
+        self::assertSame(ORMProvider::class, $operation->getProvider());
+        self::assertSame(ORMProcessor::class, $operation->getProcessor());
+        self::assertSame(['POST', 'PUT', 'GET'], $operation->getMethods());
+        self::assertSame('lag_admin.ui.process_success', $operation->getSuccessMessage());
+    }
+}


### PR DESCRIPTION
## What

Adds 27 unit test files under `tests/unit/Metadata/Attribute/`, one per attribute class: defaults, accessors, and the immutability of the `with*` methods.

## Why

The attribute classes carry the whole declarative surface of the bundle — everything an integrator writes — and had almost no test of their own. They were only exercised indirectly, through the factories.

Split out of #529 at review request: 1892 lines of assertions were burying the 339 lines of actual change in that PR. Nothing here is logic, so it reads quickly.

## Breaking changes

None, tests only.

## How to test

```bash
vendor/bin/phpunit --testsuite "AdminBundle Test Suite"
```