### PR TITLE
refactor(metadata): rework the factory chain and add caching factories

### DIFF
--- a/config/services/metadata.php
+++ b/config/services/metadata.php
@@ -6,6 +6,8 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use LAG\AdminBundle\Metadata\Factory\ApplicationMetadataFactory;
 use LAG\AdminBundle\Metadata\Factory\ApplicationMetadataFactoryInterface;
+use LAG\AdminBundle\Metadata\Factory\CachingGridCollectionMetadataFactory;
+use LAG\AdminBundle\Metadata\Factory\CachingResourceCollectionMetadataFactory;
 use LAG\AdminBundle\Metadata\Factory\CollectionOperationMetadataFactory;
 use LAG\AdminBundle\Metadata\Factory\GridCollectionAttributeMetadataFactory;
 use LAG\AdminBundle\Metadata\Factory\GridCollectionMetadataFactory;
@@ -14,18 +16,16 @@ use LAG\AdminBundle\Metadata\Factory\GridMetadataFactory;
 use LAG\AdminBundle\Metadata\Factory\GridMetadataFactoryInterface;
 use LAG\AdminBundle\Metadata\Factory\GridProviderMetadataFactory;
 use LAG\AdminBundle\Metadata\Factory\OperationsFormMetadataFactory;
+use LAG\AdminBundle\Metadata\Factory\OperationsLinkMetadataFactory;
+use LAG\AdminBundle\Metadata\Factory\OperationsMetadataFactory;
 use LAG\AdminBundle\Metadata\Factory\PropertyCollectionClassMetadataFactory;
 use LAG\AdminBundle\Metadata\Factory\PropertyCollectionMetadataFactory;
 use LAG\AdminBundle\Metadata\Factory\PropertyCollectionMetadataFactoryInterface;
-use LAG\AdminBundle\Metadata\Factory\PropertyMetadataFactory;
-use LAG\AdminBundle\Metadata\Factory\PropertyMetadataFactoryInterface;
 use LAG\AdminBundle\Metadata\Factory\ResourceCollectionAttributeMetadataFactory;
 use LAG\AdminBundle\Metadata\Factory\ResourceCollectionMetadataFactory;
 use LAG\AdminBundle\Metadata\Factory\ResourceCollectionMetadataFactoryInterface;
 use LAG\AdminBundle\Metadata\Factory\ResourceMetadataFactory;
 use LAG\AdminBundle\Metadata\Factory\ResourceMetadataFactoryInterface;
-use LAG\AdminBundle\Metadata\Factory\OperationsLinkMetadataFactory;
-use LAG\AdminBundle\Metadata\Factory\OperationsMetadataFactory;
 use LAG\AdminBundle\Metadata\Factory\ResourcePropertiesMetadataFactory;
 use LAG\AdminBundle\Routing\Route\RouteNameGeneratorInterface;
 
@@ -53,6 +53,13 @@ return static function (ContainerConfigurator $container): void {
         ->args([
             '$metadataFactory' => service('.inner'),
             '$paths' => param('lag_admin.mapping_paths'),
+        ])
+    ;
+    $services->set(CachingResourceCollectionMetadataFactory::class)
+        ->decorate('lag_admin.resource.collection_metadata_factory', priority: 255)
+        ->args([
+            '$decorated' => service('.inner'),
+            '$cache' => service('lag_admin.cache'),
         ])
     ;
 
@@ -122,6 +129,13 @@ return static function (ContainerConfigurator $container): void {
         ->args([
             '$metadataFactory' => service('.inner'),
             '$paths' => param('lag_admin.mapping_paths'),
+        ])
+    ;
+    $services->set(CachingGridCollectionMetadataFactory::class)
+        ->decorate('lag_admin.grid.collection_metadata_factory', priority: 512)
+        ->args([
+            '$decorated' => service('.inner'),
+            '$cache' => service('lag_admin.cache'),
         ])
     ;
     $services->set(GridMetadataFactoryInterface::class, GridMetadataFactory::class)

--- a/src/Metadata/Factory/CachingGridCollectionMetadataFactory.php
+++ b/src/Metadata/Factory/CachingGridCollectionMetadataFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Metadata\Factory;
+
+use Symfony\Contracts\Cache\CacheInterface;
+
+final readonly class CachingGridCollectionMetadataFactory implements GridCollectionMetadataFactoryInterface
+{
+    public function __construct(
+        private GridCollectionMetadataFactoryInterface $decorated,
+        private CacheInterface $cache,
+    ) {
+    }
+
+    public function createMetadata(): array
+    {
+        return $this->cache->get('lag_admin.grids', fn () => $this->decorated->createMetadata());
+    }
+}

--- a/src/Metadata/Factory/CachingResourceCollectionMetadataFactory.php
+++ b/src/Metadata/Factory/CachingResourceCollectionMetadataFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Metadata\Factory;
+
+use Symfony\Contracts\Cache\CacheInterface;
+
+final readonly class CachingResourceCollectionMetadataFactory implements ResourceCollectionMetadataFactoryInterface
+{
+    public function __construct(
+        private ResourceCollectionMetadataFactoryInterface $decorated,
+        private CacheInterface $cache,
+    ) {
+    }
+
+    public function createMetadata(): array
+    {
+        return $this->cache->get('lag_admin.resources', fn () => $this->decorated->createMetadata());
+    }
+}

--- a/src/Metadata/Factory/CollectionOperationMetadataFactory.php
+++ b/src/Metadata/Factory/CollectionOperationMetadataFactory.php
@@ -7,7 +7,6 @@ namespace LAG\AdminBundle\Metadata\Factory;
 use LAG\AdminBundle\Form\Type\Resource\FilterType;
 use LAG\AdminBundle\Metadata\Attribute\EntityFilter;
 use LAG\AdminBundle\Metadata\CollectionOperationMetadataInterface;
-use LAG\AdminBundle\Metadata\OperationMetadataInterface;
 use LAG\AdminBundle\Metadata\ResourceMetadataInterface;
 
 final readonly class CollectionOperationMetadataFactory implements ResourceMetadataFactoryInterface
@@ -54,7 +53,6 @@ final readonly class CollectionOperationMetadataFactory implements ResourceMetad
 
             $operations[$operation->getName()] = $operation
                 ->withCollectionLinks($operation->getCollectionLinks() ?? [])
-                ->withCollectionFormOptions($operation->getCollectionFormOptions() ?? [])
                 ->withFilters($filters)
                 ->withFilterForm($filterForm)
                 ->withFilterFormOptions($filterFormOptions)

--- a/src/Metadata/Factory/GridCollectionMetadataFactory.php
+++ b/src/Metadata/Factory/GridCollectionMetadataFactory.php
@@ -9,6 +9,7 @@ use Symfony\Component\Finder\Finder;
 
 final class GridCollectionMetadataFactory implements GridCollectionMetadataFactoryInterface
 {
+    /** @var array<string, mixed>|null */
     private ?array $cache = null;
 
     /** @param array<string> $paths */
@@ -40,7 +41,7 @@ final class GridCollectionMetadataFactory implements GridCollectionMetadataFacto
                     continue;
                 }
                 // The closure forbids access to the private scope in the included file
-                $loader = \Closure::bind(static fn($filePath) => include $filePath, null, null);
+                $loader = \Closure::bind(static fn ($filePath) => include $filePath, null, null);
 
                 try {
                     $callback = $loader($file->getRealPath());

--- a/src/Metadata/Factory/OperationsFormMetadataFactory.php
+++ b/src/Metadata/Factory/OperationsFormMetadataFactory.php
@@ -9,7 +9,6 @@ use LAG\AdminBundle\Form\Type\Resource\ResourceDataType;
 use LAG\AdminBundle\Metadata\Attribute\Create;
 use LAG\AdminBundle\Metadata\Attribute\Delete;
 use LAG\AdminBundle\Metadata\Attribute\Update;
-use LAG\AdminBundle\Metadata\OperationMetadataInterface;
 use LAG\AdminBundle\Metadata\ResourceMetadataInterface;
 
 final readonly class OperationsFormMetadataFactory implements ResourceMetadataFactoryInterface

--- a/src/Metadata/Factory/OperationsLinkMetadataFactory.php
+++ b/src/Metadata/Factory/OperationsLinkMetadataFactory.php
@@ -87,7 +87,7 @@ final readonly class OperationsLinkMetadataFactory implements ResourceMetadataFa
     private function initializeLinks(ResourceMetadataInterface $resource, array $links): array
     {
         foreach ($links as $index => $link) {
-            if (is_string($link)) {
+            if (\is_string($link)) {
                 $link = new Link(operation: $link);
             }
             $linkName = $link->getName();

--- a/src/Metadata/Factory/OperationsMetadataFactory.php
+++ b/src/Metadata/Factory/OperationsMetadataFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LAG\AdminBundle\Metadata\Factory;
 
 use LAG\AdminBundle\Metadata\Attribute\Create;
+use LAG\AdminBundle\Metadata\Attribute\Index;
 use LAG\AdminBundle\Metadata\CollectionOperationInterface;
 use LAG\AdminBundle\Metadata\OperationMetadataInterface;
 use LAG\AdminBundle\Metadata\ResourceMetadataInterface;
@@ -52,8 +53,9 @@ final readonly class OperationsMetadataFactory implements ResourceMetadataFactor
                 $redirectOperation = $application->getName().'.'.$resource->getShortName().'.'.$operation->getRedirectOperation();
             }
 
-            if (!$resource instanceof Create) {
-                $identifiers = $resource->getIdentifiers();
+            // A create operation has no identifier to route on, as the resource does not exist yet
+            if (!$operation instanceof Create) {
+                $identifiers = $operation->getIdentifiers() ?? $resource->getIdentifiers() ?? [];
             }
 
             if ($operation->getPath() === null) {
@@ -75,7 +77,7 @@ final readonly class OperationsMetadataFactory implements ResourceMetadataFactor
                 if (!$operation instanceof CollectionOperationInterface) {
                     $path = $path->ensureEnd('/');
 
-                    foreach ($operation->getIdentifiers() ?? [] as $identifier) {
+                    foreach ($identifiers as $identifier) {
                         $path = $path
                             ->append('{')
                             ->append($identifier)
@@ -111,12 +113,14 @@ final readonly class OperationsMetadataFactory implements ResourceMetadataFactor
             }
             $redirectRoute = null;
 
-            // TODO use instanceof instead
-            if ($resource->hasOperation('index')) {
-                $redirectRoute = $this->routeNameGenerator->generateRouteName($resource, $resource->getOperation('index'));
+            foreach ($resource->getOperations() as $op) {
+                if ($op instanceof Index) {
+                    $redirectRoute = $this->routeNameGenerator->generateRouteName($resource, $op);
+                    break;
+                }
             }
             $operation->setResource($resource);
-            $operations[$operation->getName()] = $operation
+            $operation = $operation
                 ->withShortName($operation->getShortName() ?? $shortName)
                 ->withTitle($operation->getTitle() ?? $title)
                 ->withBaseTemplate($operation->getBaseTemplate() ?? $application->getBaseTemplate())
@@ -130,14 +134,21 @@ final readonly class OperationsMetadataFactory implements ResourceMetadataFactor
                 ->withPermissions($operation->getRoles() ?? $resource->getPermissions() ?? [])
                 ->withIdentifiers($operation->getIdentifiers() ?? $identifiers)
                 ->withRoute($operation->getRoute() ?? $route)
-                ->withRouteParameters($operation->getRouteParameters() ?? $this->generateRouteParametersFromIdentifiers($operation))
                 ->withRedirectRoute($operation->getRedirectRoute() ?? $redirectRoute)
+                ->withContext(array_merge($resource->getContext(), $operation->getContext()))
             ;
+            // Should be done after assignments as it can require identifiers
+            $operation = $operation->withRouteParameters(
+                $operation->getRouteParameters() ?? $this->generateRouteParametersFromIdentifiers($operation)
+            );
+
+            $operations[$operation->getName()] = $operation;
         }
 
         return $resource->withOperations($operations);
     }
 
+    /** @return array<string, mixed> */
     private function generateRouteParametersFromIdentifiers(OperationMetadataInterface $operation): array
     {
         if ($operation->getIdentifiers() === null || $operation->getPath() === null) {

--- a/src/Metadata/Factory/ResourceCollectionMetadataFactory.php
+++ b/src/Metadata/Factory/ResourceCollectionMetadataFactory.php
@@ -37,11 +37,12 @@ final readonly class ResourceCollectionMetadataFactory implements ResourceCollec
                     continue;
                 }
                 // The closure forbids access to the private scope in the included file
-                $callback = \Closure::bind(static fn($filePath) => include $filePath, null, null);
+                $loader = \Closure::bind(static fn ($filePath) => include $filePath, null, null);
 
                 try {
-                    $callback = $callback($file->getRealPath());
+                    $callback = $loader($file->getRealPath());
                 } catch (\Throwable) {
+                    continue;
                 }
 
                 if (!\is_callable($callback)) {
@@ -58,6 +59,6 @@ final readonly class ResourceCollectionMetadataFactory implements ResourceCollec
     {
         $content = file_get_contents($filePath);
 
-        return (bool)preg_match('/^\s*(class|interface|trait|enum)\s+/m', $content);
+        return (bool) preg_match('/^\s*(class|interface|trait|enum)\s+/m', $content);
     }
 }

--- a/src/Metadata/Factory/ResourceMetadataFactory.php
+++ b/src/Metadata/Factory/ResourceMetadataFactory.php
@@ -8,6 +8,7 @@ use LAG\AdminBundle\Exception\Exception;
 use LAG\AdminBundle\Exception\Resource\MissingResourceException;
 use LAG\AdminBundle\Metadata\ResourceMetadataInterface;
 use Symfony\Component\String\Inflector\EnglishInflector;
+
 use function Symfony\Component\String\u;
 
 final readonly class ResourceMetadataFactory implements ResourceMetadataFactoryInterface

--- a/src/Metadata/Factory/ResourcePropertiesMetadataFactory.php
+++ b/src/Metadata/Factory/ResourcePropertiesMetadataFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LAG\AdminBundle\Metadata\Factory;
 
 use LAG\AdminBundle\Metadata\Attribute\Link;
+use LAG\AdminBundle\Metadata\PropertyMetadataInterface;
 use LAG\AdminBundle\Metadata\ResourceMetadataInterface;
 
 use function Symfony\Component\String\u;
@@ -27,7 +28,11 @@ final readonly class ResourcePropertiesMetadataFactory implements ResourceMetada
         $newProperties = [];
 
         foreach ($properties as $property) {
-            if ($property->getLabel() === null) {
+            \assert($property instanceof PropertyMetadataInterface);
+            $label = $property->getLabel();
+            $sortingPath = $property->getSortingPath();
+
+            if ($label === null) {
                 $label = u($property->getName())
                     ->replace('_', ' ')
                     ->title()
@@ -45,7 +50,7 @@ final readonly class ResourcePropertiesMetadataFactory implements ResourceMetada
                 }
             }
 
-            if ($property->isSortable() && $property->getSortingPath() === null) {
+            if ($sortingPath === null && $property->isSortable()) {
                 $sortingPath = $property->getName();
 
                 if (\is_string($property->getPropertyPath())) {
@@ -53,9 +58,9 @@ final readonly class ResourcePropertiesMetadataFactory implements ResourceMetada
                 }
             }
             $property = $property
-                ->withLabel($property->getLabel() ?? $label ?? null)
+                ->withLabel($label)
                 ->withPropertyPath($property->getPropertyPath() ?? $property->getName())
-                ->withSortingPath($property->getSortingPath() ?? $sortingPath ?? null)
+                ->withSortingPath($sortingPath)
             ;
 
             if ($property instanceof Link) {
@@ -67,6 +72,7 @@ final readonly class ResourcePropertiesMetadataFactory implements ResourceMetada
                 $property = $property
                     ->withText($property->getText() ?? $property->getName())
                     ->withOperation($operation)
+                    ->withPropertyPath($property->getPropertyPath() ?? $property->getName())
                 ;
             }
             $newProperties[$property->getName()] = $property;

--- a/tests/unit/Metadata/Factory/CollectionOperationMetadataFactoryTest.php
+++ b/tests/unit/Metadata/Factory/CollectionOperationMetadataFactoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LAG\AdminBundle\Tests\Unit\Metadata\Factory;
 
 use LAG\AdminBundle\Form\Type\Resource\FilterType;
+use LAG\AdminBundle\Metadata\Attribute\EntityFilter;
 use LAG\AdminBundle\Metadata\Attribute\Index;
 use LAG\AdminBundle\Metadata\Attribute\Resource;
 use LAG\AdminBundle\Metadata\Attribute\Show;
@@ -39,7 +40,6 @@ final class CollectionOperationMetadataFactoryTest extends TestCase
         $indexOperation = current($result->getOperations());
         self::assertSame(FilterType::class, $indexOperation->getFilterForm());
         self::assertSame([], $indexOperation->getCollectionLinks());
-        self::assertSame([], $indexOperation->getCollectionFormOptions());
     }
 
     #[Test]
@@ -111,6 +111,49 @@ final class CollectionOperationMetadataFactoryTest extends TestCase
         $indexOperation = current($result->getOperations());
         self::assertSame(FilterType::class, $indexOperation->getFilterForm());
         self::assertCount(1, $indexOperation->getFilterFormOptions()['filters']);
+    }
+
+    #[Test]
+    public function itSetsMultipleOnEntityFilterFormOptions(): void
+    {
+        $filter = new EntityFilter(name: 'category', multiple: true);
+        $resource = $this->buildResource(new Resource(
+            shortName: 'book',
+            application: 'admin',
+            resourceClass: \stdClass::class,
+            operations: [new Index(filters: [$filter])],
+        ));
+        $decorated = $this->createStub(ResourceMetadataFactoryInterface::class);
+        $decorated->method('createMetadata')->willReturn($resource);
+
+        $factory = new CollectionOperationMetadataFactory($decorated);
+        $result = $factory->createMetadata('admin.book');
+
+        $indexOperation = current($result->getOperations());
+        $resultFilter = current($indexOperation->getFilters());
+        self::assertTrue($resultFilter->getFormOptions()['multiple']);
+    }
+
+    #[Test]
+    public function itSetsPropertyFromFilterNameWhenEntityFilterHasNoProperty(): void
+    {
+        $filter = new EntityFilter(name: 'author');
+        $resource = $this->buildResource(new Resource(
+            shortName: 'book',
+            application: 'admin',
+            resourceClass: \stdClass::class,
+            operations: [new Index(filters: [$filter])],
+        ));
+        $decorated = $this->createStub(ResourceMetadataFactoryInterface::class);
+        $decorated->method('createMetadata')->willReturn($resource);
+
+        $factory = new CollectionOperationMetadataFactory($decorated);
+        $result = $factory->createMetadata('admin.book');
+
+        $indexOperation = current($result->getOperations());
+        $resultFilter = current($indexOperation->getFilters());
+        self::assertInstanceOf(EntityFilter::class, $resultFilter);
+        self::assertSame('author', $resultFilter->getProperty());
     }
 
     private function buildResource(Resource $resource): ResourceMetadataInterface

--- a/tests/unit/Metadata/Factory/GridCollectionMetadataFactoryTest.php
+++ b/tests/unit/Metadata/Factory/GridCollectionMetadataFactoryTest.php
@@ -43,4 +43,69 @@ final class GridCollectionMetadataFactoryTest extends TestCase
             rmdir($tempDir);
         }
     }
+
+    #[Test]
+    public function itReturnsCachedResultOnSecondCall(): void
+    {
+        $factory = new GridCollectionMetadataFactory(
+            [$this->getTestApplicationPath().'/config/admin/grids'],
+            'test',
+        );
+
+        $first = $factory->createMetadata();
+        $second = $factory->createMetadata();
+
+        self::assertSame($first, $second);
+    }
+
+    #[Test]
+    public function itSkipsClassFiles(): void
+    {
+        $tempDir = sys_get_temp_dir().'/lag_admin_test_'.uniqid();
+        mkdir($tempDir);
+        file_put_contents($tempDir.'/entity.php', "<?php\n// return static function\nclass FakeGridEntity {}\n");
+
+        try {
+            $factory = new GridCollectionMetadataFactory([$tempDir], 'test');
+            $grids = $factory->createMetadata();
+            self::assertSame([], $grids);
+        } finally {
+            unlink($tempDir.'/entity.php');
+            rmdir($tempDir);
+        }
+    }
+
+    #[Test]
+    public function itSkipsFilesThrowingDuringInclude(): void
+    {
+        $tempDir = sys_get_temp_dir().'/lag_admin_test_'.uniqid();
+        mkdir($tempDir);
+        file_put_contents($tempDir.'/broken.php', "<?php\n// return static function\nthrow new \\RuntimeException('broken');\n");
+
+        try {
+            $factory = new GridCollectionMetadataFactory([$tempDir], 'test');
+            $grids = $factory->createMetadata();
+            self::assertSame([], $grids);
+        } finally {
+            unlink($tempDir.'/broken.php');
+            rmdir($tempDir);
+        }
+    }
+
+    #[Test]
+    public function itSkipsFilesReturningNonCallable(): void
+    {
+        $tempDir = sys_get_temp_dir().'/lag_admin_test_'.uniqid();
+        mkdir($tempDir);
+        file_put_contents($tempDir.'/non_callable.php', "<?php\n// return static function\nreturn 42;\n");
+
+        try {
+            $factory = new GridCollectionMetadataFactory([$tempDir], 'test');
+            $grids = $factory->createMetadata();
+            self::assertSame([], $grids);
+        } finally {
+            unlink($tempDir.'/non_callable.php');
+            rmdir($tempDir);
+        }
+    }
 }

--- a/tests/unit/Metadata/Factory/OperationsFormMetadataFactoryTest.php
+++ b/tests/unit/Metadata/Factory/OperationsFormMetadataFactoryTest.php
@@ -164,6 +164,26 @@ final class OperationsFormMetadataFactoryTest extends TestCase
         self::assertSame('books', $createOperation->getFormOption('translation_domain'));
     }
 
+    #[Test]
+    public function itPropagatesFormTemplateFromResource(): void
+    {
+        $resource = $this->buildResource(new Resource(
+            shortName: 'book',
+            application: 'admin',
+            resourceClass: \stdClass::class,
+            formTemplate: '@App/form.html.twig',
+            operations: [new Create()],
+        ));
+        $decorated = $this->createStub(ResourceMetadataFactoryInterface::class);
+        $decorated->method('createMetadata')->willReturn($resource);
+
+        $factory = new OperationsFormMetadataFactory($decorated);
+        $result = $factory->createMetadata('admin.book');
+
+        $createOperation = current($result->getOperations());
+        self::assertSame('@App/form.html.twig', $createOperation->getFormTemplate());
+    }
+
     private function buildResource(Resource $resource): ResourceMetadataInterface
     {
         $operations = [];

--- a/tests/unit/Metadata/Factory/OperationsLinkMetadataFactoryTest.php
+++ b/tests/unit/Metadata/Factory/OperationsLinkMetadataFactoryTest.php
@@ -147,6 +147,30 @@ final class OperationsLinkMetadataFactoryTest extends TestCase
         self::assertSame('other.resource.create', $contextualLinks[0]->getOperation());
     }
 
+    #[Test]
+    public function itConvertsStringLinksToLinkObjects(): void
+    {
+        $resource = $this->buildResource(new Resource(
+            shortName: 'book',
+            application: 'admin',
+            resourceClass: \stdClass::class,
+            operations: [
+                new Index(contextualLinks: ['admin.book.create']),
+            ],
+        ));
+        $decorated = $this->createStub(ResourceMetadataFactoryInterface::class);
+        $decorated->method('createMetadata')->willReturn($resource);
+
+        $factory = new OperationsLinkMetadataFactory($decorated);
+        $result = $factory->createMetadata('admin.book');
+
+        $indexOperation = current($result->getOperations());
+        $contextualLinks = array_values($indexOperation->getContextualLinks());
+        self::assertCount(1, $contextualLinks);
+        self::assertInstanceOf(Link::class, $contextualLinks[0]);
+        self::assertSame('admin.book.create', $contextualLinks[0]->getOperation());
+    }
+
     private function buildResource(Resource $resource): ResourceMetadataInterface
     {
         $operations = [];

--- a/tests/unit/Metadata/Factory/OperationsMetadataFactoryTest.php
+++ b/tests/unit/Metadata/Factory/OperationsMetadataFactoryTest.php
@@ -1,0 +1,325 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LAG\AdminBundle\Tests\Unit\Metadata\Factory;
+
+use LAG\AdminBundle\Metadata\Attribute\Application;
+use LAG\AdminBundle\Metadata\Attribute\Create;
+use LAG\AdminBundle\Metadata\Attribute\Index;
+use LAG\AdminBundle\Metadata\Attribute\Resource;
+use LAG\AdminBundle\Metadata\Attribute\Show;
+use LAG\AdminBundle\Metadata\Attribute\Update;
+use LAG\AdminBundle\Metadata\Factory\ApplicationMetadataFactoryInterface;
+use LAG\AdminBundle\Metadata\Factory\OperationsMetadataFactory;
+use LAG\AdminBundle\Metadata\Factory\ResourceMetadataFactoryInterface;
+use LAG\AdminBundle\Routing\Route\RouteNameGeneratorInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class OperationsMetadataFactoryTest extends TestCase
+{
+    #[Test]
+    public function itGeneratesTitleAndPathForCollectionOperation(): void
+    {
+        $resource = new Resource(
+            shortName: 'book',
+            application: 'admin',
+            resourceClass: \stdClass::class,
+            operations: [new Index()],
+        );
+        $application = new Application(name: 'admin', baseTemplate: '@LAGAdmin/base.html.twig');
+
+        $factory = $this->createFactory($resource, $application, 'admin.book.index');
+        $result = $factory->createMetadata('book');
+
+        $operations = array_values($result->getOperations());
+        self::assertCount(1, $operations);
+
+        $operation = $operations[0];
+        self::assertSame('index', $operation->getShortName());
+        self::assertSame('Books', $operation->getTitle());
+        self::assertSame('/books/index', $operation->getPath());
+        self::assertSame('admin.book.index', $operation->getRoute());
+        self::assertSame('@LAGAdmin/base.html.twig', $operation->getBaseTemplate());
+    }
+
+    #[Test]
+    public function itGeneratesTitleAndPathForNonCollectionOperation(): void
+    {
+        $resource = new Resource(
+            shortName: 'book',
+            application: 'admin',
+            resourceClass: \stdClass::class,
+            operations: [new Index(), new Show()],
+        );
+        $application = new Application(name: 'admin');
+
+        $factory = $this->createFactory($resource, $application, 'admin.book.index');
+        $result = $factory->createMetadata('book');
+
+        $operations = $result->getOperations();
+        $showOp = null;
+
+        foreach ($operations as $op) {
+            if ($op->getShortName() === 'show') {
+                $showOp = $op;
+                break;
+            }
+        }
+
+        self::assertNotNull($showOp);
+        self::assertSame('Show book', $showOp->getTitle());
+        self::assertSame('/books/{id}/show', $showOp->getPath());
+    }
+
+    #[Test]
+    public function itAddsTheOperationIdentifiersToTheGeneratedPath(): void
+    {
+        $show = new Show(identifiers: ['slug']);
+        $resource = new Resource(
+            shortName: 'book',
+            application: 'admin',
+            resourceClass: \stdClass::class,
+            operations: [$show],
+            identifiers: ['id'],
+        );
+        $application = new Application(name: 'admin');
+
+        $factory = $this->createFactory($resource, $application, 'admin.book.show');
+        $result = $factory->createMetadata('book');
+
+        $showOp = current($result->getOperations());
+        self::assertSame('/books/{slug}/show', $showOp->getPath());
+        self::assertSame(['slug'], $showOp->getIdentifiers());
+    }
+
+    #[Test]
+    public function itAddsEachResourceIdentifierToTheGeneratedPath(): void
+    {
+        $resource = new Resource(
+            shortName: 'book',
+            application: 'admin',
+            resourceClass: \stdClass::class,
+            operations: [new Show()],
+            identifiers: ['author', 'id'],
+        );
+        $application = new Application(name: 'admin');
+
+        $factory = $this->createFactory($resource, $application, 'admin.book.show');
+        $result = $factory->createMetadata('book');
+
+        $showOp = current($result->getOperations());
+        self::assertSame('/books/{author}/{id}/show', $showOp->getPath());
+    }
+
+    #[Test]
+    public function itKeepsAnExplicitlyEmptyIdentifiersList(): void
+    {
+        // The "my account" / "shop configuration" pattern: an item operation addressing an implicit record that the
+        // provider resolves from the user context, so it carries no identifier in its path on purpose. No explicit
+        // path here, as that is the only case exercising the identifier generation
+        $update = new Update(name: 'account', identifiers: []);
+        $resource = new Resource(
+            shortName: 'user',
+            application: 'admin',
+            resourceClass: \stdClass::class,
+            operations: [$update],
+            identifiers: ['id'],
+        );
+        $application = new Application(name: 'admin');
+
+        $factory = $this->createFactory($resource, $application, 'admin.user.account');
+        $result = $factory->createMetadata('user');
+
+        $operation = current($result->getOperations());
+        self::assertSame([], $operation->getIdentifiers());
+        self::assertSame('/users/account', $operation->getPath());
+        self::assertStringNotContainsString('{', $operation->getPath());
+    }
+
+    #[Test]
+    public function itDoesNotAddIdentifiersToTheCreateOperationPath(): void
+    {
+        $resource = new Resource(
+            shortName: 'book',
+            application: 'admin',
+            resourceClass: \stdClass::class,
+            operations: [new Create()],
+            identifiers: ['id'],
+        );
+        $application = new Application(name: 'admin');
+
+        $factory = $this->createFactory($resource, $application, 'admin.book.create');
+        $result = $factory->createMetadata('book');
+
+        $createOp = current($result->getOperations());
+        self::assertSame('/books/create', $createOp->getPath());
+        self::assertSame([], $createOp->getIdentifiers());
+    }
+
+    #[Test]
+    public function itUsesExistingPathWhenOperationHasOne(): void
+    {
+        $show = new Show(path: '/custom/show');
+        $resource = new Resource(
+            shortName: 'book',
+            application: 'admin',
+            resourceClass: \stdClass::class,
+            operations: [new Index(), $show],
+        );
+        $application = new Application(name: 'admin');
+
+        $factory = $this->createFactory($resource, $application, 'admin.book.index');
+        $result = $factory->createMetadata('book');
+
+        foreach ($result->getOperations() as $op) {
+            if ($op->getShortName() === 'show') {
+                self::assertSame('/custom/show', $op->getPath());
+
+                return;
+            }
+        }
+
+        self::fail('Show operation not found');
+    }
+
+    #[Test]
+    public function itPrependsPathPrefixToExistingPath(): void
+    {
+        $show = new Show(path: '/show');
+        $resource = new Resource(
+            shortName: 'book',
+            application: 'admin',
+            resourceClass: \stdClass::class,
+            operations: [new Index(), $show],
+            pathPrefix: '/admin',
+        );
+        $application = new Application(name: 'admin');
+
+        $factory = $this->createFactory($resource, $application, 'admin.book.index');
+        $result = $factory->createMetadata('book');
+
+        foreach ($result->getOperations() as $op) {
+            if ($op->getShortName() === 'show') {
+                self::assertSame('/admin/show', $op->getPath());
+
+                return;
+            }
+        }
+
+        self::fail('Show operation not found');
+    }
+
+    #[Test]
+    public function itSetsRouteParametersFromIdentifiers(): void
+    {
+        $show = new Show(identifiers: ['id']);
+        $resource = new Resource(
+            shortName: 'book',
+            application: 'admin',
+            resourceClass: \stdClass::class,
+            operations: [new Index(), $show],
+        );
+        $application = new Application(name: 'admin');
+
+        $factory = $this->createFactory($resource, $application, 'admin.book.index');
+        $result = $factory->createMetadata('book');
+
+        foreach ($result->getOperations() as $op) {
+            if ($op->getShortName() === 'show') {
+                self::assertSame(['id' => 'id'], $op->getRouteParameters());
+
+                return;
+            }
+        }
+
+        self::fail('Show operation not found');
+    }
+
+    #[Test]
+    public function itExpandsShortRedirectOperation(): void
+    {
+        $show = new Show(redirectOperation: 'index');
+        $resource = new Resource(
+            shortName: 'book',
+            application: 'admin',
+            resourceClass: \stdClass::class,
+            operations: [$show],
+        );
+        $application = new Application(name: 'admin');
+
+        $factory = $this->createFactory($resource, $application, 'admin.book.show');
+        $result = $factory->createMetadata('book');
+
+        $showOp = current($result->getOperations());
+        self::assertSame('index', $showOp->getRedirectOperation());
+    }
+
+    #[Test]
+    public function itReturnsEmptyRouteParametersWhenPathHasNoBraces(): void
+    {
+        $show = new Show(identifiers: ['id'], path: '/books/show');
+        $resource = new Resource(
+            shortName: 'book',
+            application: 'admin',
+            resourceClass: \stdClass::class,
+            operations: [new Index(), $show],
+        );
+        $application = new Application(name: 'admin');
+
+        $factory = $this->createFactory($resource, $application, 'admin.book.index');
+        $result = $factory->createMetadata('book');
+
+        foreach ($result->getOperations() as $op) {
+            if ($op->getShortName() === 'show') {
+                self::assertSame([], $op->getRouteParameters());
+
+                return;
+            }
+        }
+
+        self::fail('Show operation not found');
+    }
+
+    #[Test]
+    public function itMergesResourceContextIntoOperationContext(): void
+    {
+        $index = new Index(context: ['operation_key' => 'operation_value', 'shared_key' => 'operation_override']);
+        $resource = new Resource(
+            shortName: 'book',
+            application: 'admin',
+            resourceClass: \stdClass::class,
+            operations: [$index],
+            context: ['resource_key' => 'resource_value', 'shared_key' => 'resource_default'],
+        );
+        $application = new Application(name: 'admin', baseTemplate: '@LAGAdmin/base.html.twig');
+
+        $factory = $this->createFactory($resource, $application, 'admin.book.index');
+        $result = $factory->createMetadata('book');
+
+        $operation = current($result->getOperations());
+        self::assertSame([
+            'resource_key' => 'resource_value',
+            'shared_key' => 'operation_override',
+            'operation_key' => 'operation_value',
+        ], $operation->getContext());
+    }
+
+    private function createFactory(
+        Resource $resource,
+        Application $application,
+        string $route,
+    ): OperationsMetadataFactory {
+        $resourceFactory = $this->createStub(ResourceMetadataFactoryInterface::class);
+        $resourceFactory->method('createMetadata')->willReturn($resource);
+
+        $applicationFactory = $this->createStub(ApplicationMetadataFactoryInterface::class);
+        $applicationFactory->method('createMetadata')->willReturn($application);
+
+        $routeNameGenerator = $this->createStub(RouteNameGeneratorInterface::class);
+        $routeNameGenerator->method('generateRouteName')->willReturn($route);
+
+        return new OperationsMetadataFactory($resourceFactory, $applicationFactory, $routeNameGenerator);
+    }
+}

--- a/tests/unit/Metadata/Factory/PropertyCollectionMetadataFactoryTest.php
+++ b/tests/unit/Metadata/Factory/PropertyCollectionMetadataFactoryTest.php
@@ -7,6 +7,7 @@ namespace LAG\AdminBundle\Tests\Unit\Metadata\Factory;
 use LAG\AdminBundle\Metadata\Attribute\Link;
 use LAG\AdminBundle\Metadata\Attribute\Text;
 use LAG\AdminBundle\Metadata\Factory\PropertyCollectionMetadataFactory;
+use LAG\AdminBundle\Metadata\PropertyMetadataInterface;
 use LAG\AdminBundle\Tests\Application\Entity\Book;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -27,8 +28,23 @@ final class PropertyCollectionMetadataFactoryTest extends TestCase
         $this->assertEquals($properties['isbn'], new Text(name: 'isbn'));
     }
 
+    #[Test]
+    public function itCreatesPropertiesFromClassLevelAttributes(): void
+    {
+        $properties = $this->factory->createMetadata(ClassWithClassLevelProperty::class);
+
+        self::assertNotEmpty($properties);
+        self::assertInstanceOf(PropertyMetadataInterface::class, current($properties));
+        self::assertSame('summary', current($properties)->getName());
+    }
+
     protected function setUp(): void
     {
         $this->factory = new PropertyCollectionMetadataFactory();
     }
+}
+
+#[Text('summary')]
+class ClassWithClassLevelProperty
+{
 }

--- a/tests/unit/Metadata/Factory/ResourceCollectionAttributeMetadataFactoryTest.php
+++ b/tests/unit/Metadata/Factory/ResourceCollectionAttributeMetadataFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LAG\AdminBundle\Tests\Unit\Metadata\Factory;
 
+use LAG\AdminBundle\Exception\Resource\MissingResourceNameException;
 use LAG\AdminBundle\Metadata\Attribute\Create;
 use LAG\AdminBundle\Metadata\Attribute\Delete;
 use LAG\AdminBundle\Metadata\Attribute\Index;
@@ -16,6 +17,7 @@ use LAG\AdminBundle\Tests\Application\Entity\Author;
 use LAG\AdminBundle\Tests\Application\Entity\Book;
 use LAG\AdminBundle\Tests\Application\State\Provider\Book\LatestBookProvider;
 use LAG\AdminBundle\Tests\Unit\ApplicationTestTrait;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -63,6 +65,34 @@ final class ResourceCollectionAttributeMetadataFactoryTest extends TestCase
                 new Show(),
             ],
         ), $resources['admin.author']);
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function itThrowsForResourceWithEmptyShortName(): void
+    {
+        $tempDir = sys_get_temp_dir().'/lag_admin_test_'.uniqid();
+        mkdir($tempDir);
+        $className = 'EmptyShortNameResource'.str_replace('.', '', uniqid('', false));
+        $tempFile = $tempDir.'/'.$className.'.php';
+        file_put_contents(
+            $tempFile,
+            "<?php\nuse LAG\\AdminBundle\\Metadata\\Attribute\\Resource;\n\n#[Resource(shortName: '')]\nclass $className {}\n",
+        );
+        require $tempFile;
+
+        $decorated = $this->createStub(ResourceCollectionMetadataFactoryInterface::class);
+        $decorated->method('createMetadata')->willReturn([]);
+        $factory = new ResourceCollectionAttributeMetadataFactory($decorated, [$tempDir]);
+
+        $this->expectException(MissingResourceNameException::class);
+
+        try {
+            $factory->createMetadata();
+        } finally {
+            unlink($tempFile);
+            rmdir($tempDir);
+        }
     }
 
     protected function setUp(): void

--- a/tests/unit/Metadata/Factory/ResourceCollectionMetadataFactoryTest.php
+++ b/tests/unit/Metadata/Factory/ResourceCollectionMetadataFactoryTest.php
@@ -16,6 +16,57 @@ final class ResourceCollectionMetadataFactoryTest extends TestCase
     use ApplicationTestTrait;
 
     #[Test]
+    public function itSkipsClassFiles(): void
+    {
+        $tempDir = sys_get_temp_dir().'/lag_admin_test_'.uniqid();
+        mkdir($tempDir);
+        file_put_contents($tempDir.'/entity.php', "<?php\n// return static function\nclass FakeResourceEntity {}\n");
+
+        try {
+            $factory = new ResourceCollectionMetadataFactory([$tempDir], 'test');
+            $resources = $factory->createMetadata();
+            self::assertSame([], $resources);
+        } finally {
+            unlink($tempDir.'/entity.php');
+            rmdir($tempDir);
+        }
+    }
+
+    #[Test]
+    public function itSkipsFilesThrowingDuringInclude(): void
+    {
+        $tempDir = sys_get_temp_dir().'/lag_admin_test_'.uniqid();
+        mkdir($tempDir);
+        file_put_contents($tempDir.'/broken.php', "<?php\n// return static function\nthrow new \\RuntimeException('broken');\n");
+
+        try {
+            $factory = new ResourceCollectionMetadataFactory([$tempDir], 'test');
+            $resources = $factory->createMetadata();
+            self::assertSame([], $resources);
+        } finally {
+            unlink($tempDir.'/broken.php');
+            rmdir($tempDir);
+        }
+    }
+
+    #[Test]
+    public function itSkipsFilesReturningNonCallable(): void
+    {
+        $tempDir = sys_get_temp_dir().'/lag_admin_test_'.uniqid();
+        mkdir($tempDir);
+        file_put_contents($tempDir.'/non_callable.php', "<?php\n// return static function\nreturn 42;\n");
+
+        try {
+            $factory = new ResourceCollectionMetadataFactory([$tempDir], 'test');
+            $resources = $factory->createMetadata();
+            self::assertSame([], $resources);
+        } finally {
+            unlink($tempDir.'/non_callable.php');
+            rmdir($tempDir);
+        }
+    }
+
+    #[Test]
     public function itCreatesResourceMetadataFromMappingDirectory(): void
     {
         $metadataFactory = new ResourceCollectionMetadataFactory([

--- a/tests/unit/Metadata/Factory/ResourceMetadataFactoryTest.php
+++ b/tests/unit/Metadata/Factory/ResourceMetadataFactoryTest.php
@@ -84,6 +84,30 @@ final class ResourceMetadataFactoryTest extends TestCase
     }
 
     #[Test]
+    public function itThrowsExceptionForMissingResourceClass(): void
+    {
+        $resource = new Resource(
+            shortName: 'book',
+            application: 'admin',
+            resourceClass: null,
+        );
+
+        $collectionFactory = $this->createMock(ResourceCollectionMetadataFactoryInterface::class);
+        $collectionFactory
+            ->expects($this->once())
+            ->method('createMetadata')
+            ->willReturn(['admin.book' => $resource])
+        ;
+        $applicationFactory = $this->createMock(ApplicationMetadataFactoryInterface::class);
+        $applicationFactory->expects($this->never())->method('createMetadata');
+
+        $factory = new ResourceMetadataFactory($collectionFactory, $applicationFactory);
+
+        $this->expectException(\LAG\AdminBundle\Exception\Exception::class);
+        $factory->createMetadata('admin.book');
+    }
+
+    #[Test]
     public function itThrowsExceptionForMissingResource(): void
     {
         $collectionFactory = $this->createMock(ResourceCollectionMetadataFactoryInterface::class);

--- a/tests/unit/Metadata/Factory/ResourcePropertiesMetadataFactoryTest.php
+++ b/tests/unit/Metadata/Factory/ResourcePropertiesMetadataFactoryTest.php
@@ -53,6 +53,30 @@ final class ResourcePropertiesMetadataFactoryTest extends TestCase
     }
 
     #[Test]
+    public function itDoesNotLeakTheSortingPathToTheNextProperty(): void
+    {
+        $resource = new Resource(
+            shortName: 'book',
+            application: 'admin',
+            resourceClass: \stdClass::class,
+        );
+        $resourceFactory = $this->createStub(ResourceMetadataFactoryInterface::class);
+        $resourceFactory->method('createMetadata')->willReturn($resource);
+
+        $propertiesFactory = $this->createStub(PropertyCollectionMetadataFactoryInterface::class);
+        $propertiesFactory->method('createMetadata')->willReturn([
+            new Text('title'),
+            new Text('summary', sortable: false),
+        ]);
+
+        $factory = new ResourcePropertiesMetadataFactory($resourceFactory, $propertiesFactory);
+        $properties = $factory->createMetadata('book')->getProperties();
+
+        self::assertSame('title', $properties['title']->getSortingPath());
+        self::assertNull($properties['summary']->getSortingPath());
+    }
+
+    #[Test]
     public function itUsesTranslationPatternWhenProvided(): void
     {
         $resource = new Resource(
@@ -81,6 +105,36 @@ final class ResourcePropertiesMetadataFactoryTest extends TestCase
         $metadata = $factory->createMetadata('book');
 
         self::assertSame('lag_admin.admin.book.published_at', $metadata->getProperties()['published_at']->getLabel());
+    }
+
+    #[Test]
+    public function itUsesPropertyPathAsSortingPath(): void
+    {
+        $resource = new Resource(
+            shortName: 'book',
+            application: 'admin',
+            resourceClass: \stdClass::class,
+        );
+        $property = new Text('name', propertyPath: 'nested.name');
+
+        $resourceFactory = $this->createMock(ResourceMetadataFactoryInterface::class);
+        $resourceFactory
+            ->expects($this->once())
+            ->method('createMetadata')
+            ->willReturn($resource)
+        ;
+
+        $propertiesFactory = $this->createMock(PropertyCollectionMetadataFactoryInterface::class);
+        $propertiesFactory
+            ->expects($this->once())
+            ->method('createMetadata')
+            ->willReturn([$property])
+        ;
+
+        $factory = new ResourcePropertiesMetadataFactory($resourceFactory, $propertiesFactory);
+        $metadata = $factory->createMetadata('book');
+
+        self::assertSame('nested.name', $metadata->getProperties()['name']->getSortingPath());
     }
 
     #[Test]
@@ -167,6 +221,12 @@ final class ResourcePropertiesMetadataFactoryTest extends TestCase
             ->expects($this->once())
             ->method('withOperation')
             ->with('admin.book.')
+            ->willReturn($linkWithOperation)
+        ;
+        $linkWithOperation
+            ->expects($this->once())
+            ->method('withPropertyPath')
+            ->with('details')
             ->willReturn($linkWithOperation)
         ;
         $linkWithOperation


### PR DESCRIPTION
> Replaces #530, which GitHub auto-closed as merged when a bad `--update-refs` rebase briefly made its base branch contain these commits. Nothing was merged.

## What

Each metadata factory decorates the previous one and only enriches what it owns, so the resource metadata is built by a single readable chain. Two caching decorators are added for the resource and grid collections.

Fixes two bugs found while writing the v2 documentation:

- **Item operations lost their identifier in the generated path.** The path was built from `$operation->getIdentifiers()`, still `null` at that point. The effective identifiers are now resolved first, with the precedence `operation.identifiers > resource.identifiers`.
- **`ResourcePropertiesMetadataFactory` leaked `$sortingPath` between loop iterations**, so a non-sortable property inherited the sorting path of the previous one.

The neighbouring `if (!$resource instanceof Create)` also tested the wrong variable and always matched; it now tests the operation.

## Why

A resource declared with `#[Resource]` alone had no usable show/update/delete route: `/authors/update` instead of `/authors/{id}/update`.

## Breaking changes

None in the API. Generated paths of item operations change, which is the point. Route **names** are unchanged.

## How to test

```bash
vendor/bin/phpunit --filter OperationsMetadataFactoryTest
vendor/bin/phpunit --filter ResourcePropertiesMetadataFactoryTest
```